### PR TITLE
Fix logger export

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Read the [Kayvee spec](https://github.com/Clever/kayvee) to learn more about the
 Initialization:
 
 ```coffee
-logger = require "kayvee/logger"
+kayvee = require "kayvee"
 
-log = logger("logger-source")
+log = kayvee.logger "logger-source"
 ```
 
 Use it to write metrics:

--- a/index.js
+++ b/index.js
@@ -1,1 +1,2 @@
 module.exports = require('./lib-js/kayvee');
+module.exports.logger = require('./lib-js/kayvee/logger')

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kayvee",
   "description": "Write data to key=val pairs, for human and machine readability",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Earlier logger module was not being exported resulting in errors if you followed the directions on how to import it.

This change exports the logger module as an attribute of the exported object.

Made a patch bump since the previous one really didn't work.

Tested:
`make build` correctly creates `lib-js/logger/logger.js`.