### PR TITLE
Add express middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Run `make test` to execute the tests
 
 ## Usage
 
+### Logger
+
 #### kayvee/logger constructor
 
 ```coffee
@@ -70,7 +72,7 @@ An environment variable named `KAYVEE_LOG_LEVEL` can be used instead of setting 
 logger.setConfig source, logLvl, formatter, output
 ```
 
-You can also individually set the `config` using: 
+You can also individually set the `config` using:
 
 * `setLogLevel`: defaults to `LOG_LEVELS.Debug`
 * `setFormatter`: defaults to `kv.format`
@@ -102,6 +104,8 @@ Title + Metadata:
 * `log.counterD "counter-with-data", 2, {extra: "info"}`
 * `log.gaugeD "gauge-with-data", 2, {extra: "info"}`
 
+### Formatters
+
 #### format
 
 ```coffee
@@ -126,3 +130,45 @@ logging best-practices
     - "info"
 - `title` (string) - the event that occurred
 - `data` (object) - other parameters describing the event
+
+### Middleware
+
+Kayvee includes logging middleware, compatible with expressJS.
+
+The middleware can be added most simply via
+
+```js
+kayveeMiddleware = require('kayvee/middleware')
+
+var app = express()
+app.use(kayveeMiddleware())
+```
+
+It also supports user configuration via an `options` object.
+It prints the values of the headers or the results of the handlers.
+If a value is `undefined`, the key will not be printed.
+
+- `headers`
+    - type: array of strings
+    - each of these strings is a request header, e.g. `X-Request-Id`
+- `handlers`
+    - type: an array of functions that return dicts of key-val pairs to be added to the logger's output.
+        These functions have the interface `(request, response) => { "key": "val" }`.
+
+For example, this causes `X-Request-Id` request header and a param called `some_id` to be logged.
+
+
+```js
+kayveeMiddleware = require('kayvee/middleware')
+
+var addSomeId = function(request, response) {
+    return {"some_id": request.params.some_id}
+}
+
+var app = express()
+var options = {
+    headers: ['X-Request-Id'],
+    handlers: [addSomeId]
+}
+app.use(kayveeMiddleware(options))
+```

--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
 module.exports = require('./build/lib/kayvee');
 module.exports.logger = require('./build/lib/logger/logger')
+module.exports.middleware = require('./build/lib/middleware')

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -1,0 +1,120 @@
+'use strict'
+
+/**
+ * Module dependencies.
+ * @private
+ */
+
+var kayvee = require('../lib/kayvee')
+var morgan = require('morgan')
+var _ = require('underscore')
+
+/**
+ * request path
+ */
+
+var getBaseUrl = function(req) {
+  var url = req.originalUrl || req.url
+  var parsed = require('url').parse(url, true)
+  return parsed.pathname
+}
+
+/**
+ * request query params
+ */
+
+var getQueryParams = function(req) {
+  var url = req.originalUrl || req.url
+  var parsed = require('url').parse(url, true)
+  return parsed.search
+}
+
+/**
+ * response size
+ */
+
+var getResponseSize = function(res) {
+  var headers = res.headers || res._headers
+  if (headers && headers['content-length']) {
+    return Number(headers['content-length'])
+  } else if (res.data) {
+    return res.data.length
+  }
+}
+
+/**
+ * response time in nanoseconds
+ */
+
+var getResponseTimeNs = function(req, res) {
+  if (!req._startAt || !res._startAt) {
+    // missing request and/or response start time
+    return
+  }
+
+  // calculate diff
+  var ns = (res._startAt[0] - req._startAt[0]) * 1e9
+    + (res._startAt[1] - req._startAt[1])
+  return ns
+}
+
+/*
+ * User configuration is passed via an `options` object.
+ *
+ * // `headers` - logs these request headers, if they exist
+ * headers: e.g. ['X-Request-Id', 'Host']
+ *
+ * // `handlers` - an array of functions of that return dicts to be logged.
+ * handlers: e.g. [function(request, response) { return {"key":"val"}]
+ */
+
+var cleverFormatLine = function(options) {
+  options = options || {};
+
+  return function(tokens, req, res) {
+    // Build a dict of data to log
+    var data = {};
+
+    // Add user-configured request headers
+    var custom_headers = options.headers || [];
+    var header_data = {};
+    custom_headers.forEach(function(h) {
+      header_data[h] = req.headers[h]
+    });
+    _.extend(data, header_data);
+
+    // Run user-configured handlers; add custom data
+    var custom_handlers = options.handlers || [];
+    custom_handlers.forEach(function(h) {
+      try {
+        var handler_data = h(req, res);
+        _.extend(data, handler_data);
+      } catch (e) {
+        // ignore invalid handler
+      }
+    });
+
+    // Add default request fields
+    var default_data = {
+      "method": req.method,
+      "path": getBaseUrl(req),
+      "params": getQueryParams(req),
+      "response-size": getResponseSize(res),
+      "response-time": getResponseTimeNs(req, res),
+      "status-code": res.statusCode,
+      "x-forwarded-for": req.headers['x-forwarded-for'],
+    }
+    _.extend(data, default_data);
+
+    return kayvee.format(data)
+  }
+}
+
+/**
+ * Module exports.
+ * @public
+ */
+
+module.exports = function(clever_options, morgan_options) {
+  return morgan(cleverFormatLine(clever_options), morgan_options)
+}

--- a/package.json
+++ b/package.json
@@ -8,9 +8,12 @@
     "url": "git://github.com/Clever/kayvee-node"
   },
   "dependencies": {
+    "morgan": "^1.7.0",
+    "split": "^1.0.0",
+    "supertest": "^1.2.0",
     "ts-node": "^0.7.1",
     "typescript": "^1.8.9",
-    "underscore": "~1.5.2"
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "coffee-script": "~1.6.3",

--- a/test/middleware.ts
+++ b/test/middleware.ts
@@ -1,0 +1,264 @@
+var assert = require('assert')
+var http = require('http')
+var morgan = require('morgan')
+var request = require('supertest')
+var split = require('split')
+var kayvee = require('../lib/kayvee')
+var kv_middleware = require('../lib/middleware')
+
+describe('middleware', function () {
+  var expected;
+  it('should pass default fields', function (done) {
+    var cb = afterTest(2, function (err, res, line) {
+      if (err) return done(err)
+      var masked = line.replace(/response-time\":\d+/, 'response-time":99999')
+      expected = kayvee.format({
+        "method": "GET",
+        "path": "/hello/world",
+        "params": "?a=1&b=2",
+        "response-size": 12345,
+        "response-time": 99999,
+        "status-code": 200,
+        "x-forwarded-for": "foo",
+      })
+      assert.equal(masked, expected)
+      done()
+    })
+
+    var stream = createLineStream(function (line) {
+      cb(null, null, line)
+    })
+
+    var options = undefined;
+
+    var server = createServer(options, { stream: stream }, function (req, res, next) {
+      res.setHeader('some-header', 'some-header-value')
+      res.setHeader('content-length', 12345)
+      next()
+    })
+
+    request(server)
+    .get('/hello/world?a=1&b=2')
+    .set('x-forwarded-for', 'foo')
+    .expect(200, cb)
+  })
+
+  it('should allow logging user-specified request headers', function (done) {
+    var cb = afterTest(2, function (err, res, line) {
+      if (err) return done(err)
+      var masked = line.replace(/response-time\":\d+/, 'response-time":99999')
+      expected = kayvee.format({
+        'some-header': 'some-header-value',
+        'another-header': 'another-header-value',
+        "method": "GET",
+        "path": "/hello/world",
+        "params": "?a=1&b=2",
+        "response-size": 12345,
+        "response-time": 99999,
+        "status-code": 200,
+        "x-forwarded-for": "foo",
+      })
+      assert.equal(masked, expected)
+      done()
+    })
+
+    var stream = createLineStream(function (line) {
+      cb(null, null, line)
+    })
+
+    var options = {
+      headers: ['some-header', 'another-header'],
+    };
+
+    var server = createServer(options, { stream: stream }, function (req, res, next) {
+      res.setHeader('content-length', 12345)
+      next()
+    })
+
+    request(server)
+    .get('/hello/world?a=1&b=2')
+    .set('some-header', 'some-header-value')
+    .set('another-header', 'another-header-value')
+    .set('x-forwarded-for', 'foo')
+    .expect(200, cb)
+  })
+
+  it('should allow logging from user-specified handlers', function (done) {
+    var cb = afterTest(2, function (err, res, line) {
+      if (err) return done(err)
+      var masked = line.replace(/response-time\":\d+/, 'response-time":99999')
+      expected = kayvee.format({
+        "global": 1,
+        "global2": 2,
+        "url": '/hello/world?a=1&b=2',
+        "method": "GET",
+        "path": "/hello/world",
+        "params": "?a=1&b=2",
+        "response-size": 12345,
+        "response-time": 99999,
+        "status-code": 200,
+        "x-forwarded-for": "foo",
+      })
+      assert.equal(masked, expected)
+      done()
+    })
+
+    var stream = createLineStream(function (line) {
+      cb(null, null, line)
+    })
+
+    var options = {
+      handlers: [
+        function(req, res) {return {"global": 1}},
+        function(req, res) {return {"global2": 2}},
+        function(req, res) {return {"url": req.url }},
+      ]
+    };
+
+    var server = createServer(options, { stream: stream }, function (req, res, next) {
+      res.setHeader('content-length', 12345)
+      next()
+    })
+
+    request(server)
+    .get('/hello/world?a=1&b=2')
+    .set('x-forwarded-for', 'foo')
+    .expect(200, cb)
+  })
+
+  it('should not log null or undefined values', function (done) {
+    var cb = afterTest(2, function (err, res, line) {
+      if (err) return done(err)
+      var masked = line.replace(/response-time\":\d+/, 'response-time":99999')
+      expected = kayvee.format({
+        "method": "GET",
+        "path": "/hello/world",
+        "params": "?a=1&b=2",
+        "response-size": 12345,
+        "response-time": 99999,
+        "status-code": 200,
+        "x-forwarded-for": "foo",
+      })
+      assert.equal(masked, expected)
+      done()
+    })
+
+    var stream = createLineStream(function (line) {
+      cb(null, null, line)
+    })
+
+    var options = {
+      // These values should not be logged
+      headers: ['this-header-dne'],
+      handlers: [
+        function() { return { "undefined": undefined } }
+      ]
+    };
+
+    var server = createServer(options, { stream: stream }, function (req, res, next) {
+      res.setHeader('content-length', 12345)
+      next()
+    })
+
+    request(server)
+    .get('/hello/world?a=1&b=2')
+    .set('x-forwarded-for', 'foo')
+    .expect(200, cb)
+  })
+
+  it('should warn on broken user-specified handlers, and keep processing', function (done) {
+    var cb = afterTest(2, function (err, res, line) {
+      if (err) return done(err)
+      var masked = line.replace(/response-time\":\d+/, 'response-time":99999')
+      expected = kayvee.format({
+        "global": 1,
+        "method": "GET",
+        "path": "/hello/world",
+        "params": "?a=1&b=2",
+        "response-size": 12345,
+        "response-time": 99999,
+        "status-code": 200,
+        "x-forwarded-for": "foo",
+      })
+      assert.equal(masked, expected)
+      done()
+    })
+
+    var stream = createLineStream(function (line) {
+      cb(null, null, line)
+    })
+
+    var options = {
+      handlers: [
+        // These handlers should be ignored
+        function(req, res) {throw("error!")},
+        function(req, res) {return req.foo.bar},
+        function(req, res) {return []},
+        // This handler should still work
+        function(req, res) {return {"global":1} },
+      ]
+    };
+
+    var server = createServer(options, { stream: stream }, function (req, res, next) {
+      res.setHeader('content-length', 12345)
+      next()
+    })
+
+    request(server)
+    .get('/hello/world?a=1&b=2')
+    .set('x-forwarded-for', 'foo')
+    .expect(200, cb)
+  })
+})
+
+/*
+ * Copied from expressjs/morgan
+ * https://github.com/expressjs/morgan/blob/master/test/morgan.js#L1332-L1380
+ *
+ * Modified `createServer`, since we are always testing Kayvee middleware here.
+ * Renamed `after` -> `afterTest`; preventing typescript errors from overloading a Mocha function.
+ */
+function afterTest(count, callback) {
+  var args = new Array(3)
+  var i = 0
+
+  return function (err, arg1, arg2) {
+    assert.ok(i++ < count, 'callback called ' + count + ' times')
+
+    args[0] = args[0] || err
+    args[1] = args[1] || arg1
+    args[2] = args[2] || arg2
+
+    if (count === i) {
+      callback.apply(null, args)
+    }
+  }
+}
+
+function createLineStream(callback) {
+  return split().on('data', callback)
+}
+
+function createServer(clever_options, morgan_options, fn) {
+  var logger = kv_middleware(clever_options, morgan_options)
+  var middle = fn || noopMiddleware
+
+  return http.createServer(function onRequest(req, res) {
+    logger(req, res, function onNext(err) {
+      // allow req, res alterations
+      middle(req, res, function onDone() {
+        if (err) {
+          res.statusCode = 500
+          res.end(err.message)
+        }
+
+        res.setHeader('X-Sent', 'true')
+        res.end((req.connection && req.connection.remoteAddress) || '-')
+      })
+    })
+  })
+}
+
+function noopMiddleware(req, res, next) {
+  next()
+}


### PR DESCRIPTION
Issue: https://clever.atlassian.net/browse/INFRA-1595

This adds `expressjs` compatible middleware that will print out Kayvee formatted logs.

See README below for usage.