### PR TITLE
Linting improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TS_FILES := $(shell find . -name "*.ts" -not -path "./node_modules/*" -not -path
 build: clean
 	./node_modules/.bin/tsc --outDir build
 
-test: tests.json $(TESTS)
+test: lint tests.json $(TESTS)
 
 $(TESTS):
 	DEBUG=us:progress NODE_ENV=test node_modules/mocha/bin/mocha --require ts-node/register --timeout 60000 test/$@.ts

--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
-module.exports = require('./build/lib/kayvee');
-module.exports.logger = require('./build/lib/logger/logger')
+module.exports = require("./build/lib/kayvee");
+module.exports.logger = require("./build/lib/logger/logger");

--- a/lib/kayvee.ts
+++ b/lib/kayvee.ts
@@ -1,40 +1,34 @@
-"use strict";
-
-var _ = require('underscore');
-
-var toKeyVal = (data) => _.map(data, (v, k) => `${k}=${JSON.stringify(v)}`);
+var _ = require("underscore");
 
 // Converts a map to a string space-delimited key=val pairs
-var format = function(data) {
+function format(data) {
   return JSON.stringify(data);
-};
+}
 
 // Similar to format, but takes additional reserved params to promote logging best-practices
-var formatLog = function(source, level, title, data) {
-  // consistently output empty string for unset keys, because null values differ by language
-  if ([null, undefined].indexOf(source) >= 0) { source = ""; }
-  if ([null, undefined].indexOf(level) >= 0) { level = ""; }
-  if ([null, undefined].indexOf(title) >= 0) { title = ""; }
-
-  var reserved = {source, level, title};
-  if (!_.isObject(data)) { data = {}; }
+function formatLog(source = "", level = "", title = "", data = {}) {
+  let reallyData = data;
+  if (!_.isObject(data)) {
+    reallyData = {};
+  }
+  const reserved = {source, level, title};
 
   // reserved keys overwrite other keys in data
-  return format(_.extend(data, reserved));
+  return format(_.extend(reallyData, reserved));
+}
+
+module.exports = {
+  format,
+  formatLog,
 };
 
-module.exports =
-  {format: format,
-  formatLog: formatLog
-  };
-
-var LOG_LEVELS =
-  {UNKNOWN: "unknown",
+const LOG_LEVELS = {
+  UNKNOWN: "unknown",
   CRITICAL: "critical",
   ERROR: "error",
   WARNING: "warning",
   INFO: "info",
-  TRACE: "trace"
-  };
+  TRACE: "trace",
+};
 
 _.extend(module.exports, LOG_LEVELS);

--- a/lib/logger/logger.ts
+++ b/lib/logger/logger.ts
@@ -1,22 +1,20 @@
-"use strict";
-
-var _ = require('underscore');
+var _ = require("underscore");
 var kv  = require("../kayvee");
 
 var LEVELS = {
-  "Debug":    "debug",
-  "Info":     "info",
-  "Warning":  "warning",
-  "Error":    "error",
-  "Critical": "critical",
+  Debug:    "debug",
+  Info:     "info",
+  Warning:  "warning",
+  Error:    "error",
+  Critical: "critical",
 };
 
 var LOG_LEVEL_ENUM = {
-  "debug":    0,
-  "info":     1,
-  "warning":  2,
-  "error":    3,
-  "critical": 4,
+  debug:    0,
+  info:     1,
+  warning:  2,
+  error:    3,
+  critical: 4,
 };
 
 // This is a port from kayvee-go/logger/logger.go
@@ -26,34 +24,31 @@ class Logger {
   globals = null;
   logWriter = null;
 
-  constructor(source, logLvl=null, formatter=kv.format, output=console.error) {
+  constructor(source, logLvl = process.env.KAYVEE_LOG_LEVEL, formatter = kv.format, output = console.error) {
     this.formatter = formatter;
-    if (!(typeof logLvl !== "undefined" && logLvl !== null)) {
-      logLvl = process.env.KAYVEE_LOG_LEVEL;
-    }
     this.logLvl = this._validateLogLvl(logLvl);
     this.globals = {};
-    this.globals["source"] = source;
+    this.globals.source = source;
     this.logWriter = output;
   }
 
   setConfig(source, logLvl, formatter, output) {
-    this.globals["source"] = source;
+    this.globals.source = source;
     this.logLvl = this._validateLogLvl(logLvl);
     this.formatter = formatter;
-    return this.logWriter = output;
+    this.logWriter = output;
+    return this.logWriter;
   }
 
   _validateLogLvl(logLvl) {
-    if (!(typeof logLvl !== "undefined" && logLvl !== null)) {
+    if (logLvl == null) {
       return LEVELS.Debug;
-    } else {
-      for (var key in LEVELS) {
-        if (Object.prototype.hasOwnProperty.call(LEVELS, key)) {
-          var value = LEVELS[key];
-          if (logLvl.toLowerCase() === value) {
-            return value;
-          }
+    }
+    for (var key in LEVELS) {
+      if (Object.prototype.hasOwnProperty.call(LEVELS, key)) {
+        var value = LEVELS[key];
+        if (logLvl.toLowerCase() === value) {
+          return value;
         }
       }
     }
@@ -61,99 +56,94 @@ class Logger {
   }
 
   setLogLevel(logLvl) {
-    return this.logLvl = this._validateLogLvl(logLvl);
+    this.logLvl = this._validateLogLvl(logLvl);
+    return this.logLvl;
   }
 
   setFormatter(formatter) {
-    return this.formatter = formatter;
+    this.formatter = formatter;
+    return this.formatter;
   }
 
   setOutput(output) {
-    return this.logWriter = output;
+    this.logWriter = output;
+    return this.logWriter;
   }
 
   debug(title) {
-    return this.debugD(title, {});
+    this.debugD(title, {});
   }
 
   info(title) {
-    return this.infoD(title, {});
+    this.infoD(title, {});
   }
 
   warn(title) {
-    return this.warnD(title, {});
+    this.warnD(title, {});
   }
 
   error(title) {
-    return this.errorD(title, {});
+    this.errorD(title, {});
   }
 
   critical(title) {
-    return this.criticalD(title, {});
+    this.criticalD(title, {});
   }
 
   counter(title) {
-    return this.counterD(title, 1, {});
+    this.counterD(title, 1, {});
   }
 
   gauge(title, value) {
-    return this.gaugeD(title, value, {});
+    this.gaugeD(title, value, {});
   }
 
   debugD(title, data) {
-    data["title"] = title;
-    return this.logWithLevel(LEVELS.Debug, data);
+    data.title = title;
+    this.logWithLevel(LEVELS.Debug, data);
   }
 
   infoD(title, data) {
-    data["title"] = title;
-    return this.logWithLevel(LEVELS.Info, data);
+    data.title = title;
+    this.logWithLevel(LEVELS.Info, data);
   }
 
   warnD(title, data) {
-    data["title"] = title;
-    return this.logWithLevel(LEVELS.Warning, data);
+    data.title = title;
+    this.logWithLevel(LEVELS.Warning, data);
   }
 
   errorD(title, data) {
-    data["title"] = title;
-    return this.logWithLevel(LEVELS.Error, data);
+    data.title = title;
+    this.logWithLevel(LEVELS.Error, data);
   }
 
   criticalD(title, data) {
-    data["title"] = title;
-    return this.logWithLevel(LEVELS.Critical, data);
+    data.title = title;
+    this.logWithLevel(LEVELS.Critical, data);
   }
 
   counterD(title, value, data) {
-    data["title"] = title;
-    data["value"] = value;
-    data["type"] = "counter";
-    return this.logWithLevel(LEVELS.Info, data);
+    data.title = title;
+    data.value = value;
+    data.type = "counter";
+    this.logWithLevel(LEVELS.Info, data);
   }
 
   gaugeD(title, value, data) {
-    data["title"] = title;
-    data["value"] = value;
-    data["type"] = "gauge";
-    return this.logWithLevel(LEVELS.Info, data);
+    data.title = title;
+    data.value = value;
+    data.type = "gauge";
+    this.logWithLevel(LEVELS.Info, data);
   }
 
   logWithLevel(logLvl, data) {
-    var iterable;
     if (LOG_LEVEL_ENUM[logLvl] < LOG_LEVEL_ENUM[this.logLvl]) {
       return;
     }
-    data["level"] = logLvl;
-    for (var key in (iterable = this.globals)) {
-      var value = iterable[key];
-      if (key in data) {
-        continue;
-      }
-      data[key] = value;
-    }
-    var logString = this.formatter(data);
-    return this.logWriter(logString);
+    data.level = logLvl;
+    _.defaults(data, this.globals);
+    this.logWriter(this.formatter(data));
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "devDependencies": {
     "babel-eslint": "^6.0.2",
-    "coffee-script": "~1.6.3",
     "eslint": "^2.7.0",
     "eslint-config-airbnb": "^7.0.0",
     "eslint-plugin-jsx-a11y": "^0.6.2",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,6 @@
     "url": "git://github.com/Clever/kayvee-node"
   },
   "dependencies": {
-    "ts-node": "^0.7.1",
-    "typescript": "^1.8.9",
     "underscore": "~1.5.2"
   },
   "devDependencies": {
@@ -22,6 +20,8 @@
     "lint": "^1.1.2",
     "mocha": "~1.17.0",
     "tslint": "^3.7.4",
+    "ts-node": "^0.7.1",
+    "typescript": "^1.8.9",
     "underscore.deep": "^0.5.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "coffee-script": "~1.6.3",
     "eslint": "^2.7.0",
+    "eslint-config-airbnb": "^7.0.0",
     "lint": "^1.1.2",
     "mocha": "~1.17.0",
     "tslint": "^3.7.4",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,12 @@
     "underscore": "~1.5.2"
   },
   "devDependencies": {
+    "babel-eslint": "^6.0.2",
     "coffee-script": "~1.6.3",
     "eslint": "^2.7.0",
     "eslint-config-airbnb": "^7.0.0",
+    "eslint-plugin-jsx-a11y": "^0.6.2",
+    "eslint-plugin-react": "^4.3.0",
     "lint": "^1.1.2",
     "mocha": "~1.17.0",
     "tslint": "^3.7.4",

--- a/test/kayvee.ts
+++ b/test/kayvee.ts
@@ -1,28 +1,27 @@
 var kv  = require("../lib/kayvee");
-var assert = require('assert');
-var _ = require('underscore');
-_.mixin = require('underscore.deep');
-var fs = require('fs');
+var assert = require("assert");
+var _ = require("underscore");
+_.mixin = require("underscore.deep");
+var fs = require("fs");
 
-describe('kayvee', function() {
-
-  var tests = JSON.parse(fs.readFileSync("test/tests.json"));
-  describe('.format', function() {
-    return _.each(tests['format'], function(spec) {
-      return it(spec.title, function() {
-        var actual = kv.format(spec.input.data);
-        var expected = spec.output;
-        return assert.deepEqual(JSON.parse(actual), JSON.parse(expected));
+describe("kayvee", () => {
+  const tests = JSON.parse(fs.readFileSync("test/tests.json"));
+  describe(".format", () => {
+    _.each(tests.format, (spec) => {
+      it(spec.title, () => {
+        const actual = kv.format(spec.input.data);
+        const expected = spec.output;
+        assert.deepEqual(JSON.parse(actual), JSON.parse(expected));
       });
     });
   });
 
-  return describe('.formatLog', function() {
-    return _.each(tests['formatLog'], function(spec) {
-      return it(spec.title, function() {
-        var actual = kv.formatLog(spec.input.source, spec.input.level, spec.input.title, spec.input.data);
-        var expected = spec.output;
-        return assert.deepEqual(JSON.parse(actual), JSON.parse(expected));
+  describe(".formatLog", () => {
+    _.each(tests.formatLog, (spec) => {
+      it(spec.title, () => {
+        const actual = kv.formatLog(spec.input.source, spec.input.level, spec.input.title, spec.input.data);
+        const expected = spec.output;
+        assert.deepEqual(JSON.parse(actual), JSON.parse(expected));
       });
     });
   });

--- a/test/logger_test.ts
+++ b/test/logger_test.ts
@@ -140,7 +140,8 @@ describe("logger_test", () => {
     });
     it("test counterD function", () => {
       logObj.counterD("testlogcounter", 2, {key1: "val1", key2: "val2"});
-      const expected = `{"source": "logger-tester", "level": "${kayvee.logger.Info}", "title": "testlogcounter","type": "counter", "value": 2,"key1": "val1", "key2": "val2"}`;
+      const expected = `{"source": "logger-tester", "level": "${kayvee.logger.Info}", "title": "testlogcounter","type": "counter", "value": 2,"key1": "val1",` +
+        " \"key2\": \"val2\"}";
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
   });
@@ -153,7 +154,8 @@ describe("logger_test", () => {
     });
     it("test gaugeD function", () => {
       logObj.gaugeD("testloggauge", 4, {key1: "val1", key2: "val2"});
-      const expected = `{"source": "logger-tester", "level": "${kayvee.logger.Info}", "title": "testloggauge", "type": "gauge", "value": 4, "key1": "val1", "key2": "val2"}`;
+      const expected = `{"source": "logger-tester", "level": "${kayvee.logger.Info}", "title": "testloggauge", "type": "gauge", "value": 4, "key1": "val1",` +
+        "\"key2\": \"val2\"}";
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
   });

--- a/test/logger_test.ts
+++ b/test/logger_test.ts
@@ -1,189 +1,190 @@
-var kv  = require("../lib/kayvee");
-var logger = require("../lib/logger/logger");
-var assert = require('assert');
-var _ = require('underscore');
-_.mixin = require('underscore.deep');
-var fs = require('fs');
+var kayvee = {logger: require("../lib/logger/logger")};
+var assert = require("assert");
+var _ = require("underscore");
+_.mixin = require("underscore.deep");
 
-var sample = "";
-var outputFunc = function(text) { return sample = text; };
+let sample = "";
+function outputFunc(text) {
+  sample = text;
+  return sample;
+}
 
-describe('logger_test', function() {
-  var logObj = null;
-  var logObj2 = null;
-  beforeEach(function() {
-  	logObj = new logger("logger-tester");
-  	sample = "";
-  	return logObj.setOutput(outputFunc);
+describe("logger_test", () => {
+  let logObj = null;
+  let logObj2 = null;
+  beforeEach(() => {
+    logObj = new kayvee.logger("logger-tester");
+    sample = "";
+    return logObj.setOutput(outputFunc);
   });
 
-  describe('.constructor', function() {
-    return it('passing in parameters to constructor', function() {
-      var formatter = function(data) { return data["level"] + "." + data["source"] + "." + data["title"]; };
-      logObj = new logger("logger-test", logger.Info, formatter, outputFunc);
+  describe(".constructor", () => {
+    it("passing in parameters to constructor", () => {
+      const formatter = (data) => `${data.level}.${data.source}.${data.title}`;
+      logObj = new kayvee.logger("logger-test", kayvee.logger.Info, formatter, outputFunc);
       logObj.debug("testlogdebug");
-      var expected = "";
+      let expected = "";
       assert.equal(sample, expected);
 
       logObj.info("testloginfo");
-      expected = logger.Info + ".logger-test.testloginfo";
-      return assert.equal(sample, expected);
+      expected = `${kayvee.logger.Info}.logger-test.testloginfo`;
+      assert.equal(sample, expected);
     });
   });
-  describe('.validateloglvl', function() {
+  describe(".validateloglvl", () => {
     // Explicit validation checks
-    it('is case-insensitive in log level name', function() {
-      var logLvl = logObj._validateLogLvl("debug");
-      assert.equal(logLvl, logger.Debug);
+    it("is case-insensitive in log level name", () => {
+      let logLvl = logObj._validateLogLvl("debug");
+      assert.equal(logLvl, kayvee.logger.Debug);
       logLvl = logObj._validateLogLvl("Debug");
-      return assert.equal(logLvl, logger.Debug);
+      assert.equal(logLvl, kayvee.logger.Debug);
     });
 
-    it('sets non-default log levels', function() {
-      var logLvl = logObj._validateLogLvl("info");
-      assert.equal(logLvl, logger.Info);
+    it("sets non-default log levels", () => {
+      let logLvl = logObj._validateLogLvl("info");
+      assert.equal(logLvl, kayvee.logger.Info);
       // TODO: for each possible log level ...
       logLvl = logObj._validateLogLvl("critical");
-      return assert.equal(logLvl, logger.Critical);
+      assert.equal(logLvl, kayvee.logger.Critical);
     });
 
-    return it('sets level to Debug, if given an invalid log level', function() {
-      var logLvl = logObj._validateLogLvl("sometest");
-      return assert.equal(logLvl, logger.Debug);
+    it("sets level to Debug, if given an invalid log level", () => {
+      const logLvl = logObj._validateLogLvl("sometest");
+      assert.equal(logLvl, kayvee.logger.Debug);
     });
   });
-  describe('.invalidlog', function() {
-    return it('check valid debug level JSON output of invalid log level', function() {
+  describe(".invalidlog", () => {
+    it("check valid debug level JSON output of invalid log level", () => {
       // Invalid log levels will default to debug
       logObj.setLogLevel("invalidloglevel");
       logObj.debug("testlogdebug");
-      var expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.Debug + "\", \"title\": \"testlogdebug\"}";
+      let expected = `{"source": "logger-tester", "level": "${kayvee.logger.Debug}", "title": "testlogdebug"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
 
       logObj.setLogLevel("sometest");
       logObj.info("testloginfo");
-      expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.Info + "\", \"title\": \"testloginfo\"}";
-      return assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
+      expected = `{"source": "logger-tester", "level": "${kayvee.logger.Info}", "title": "testloginfo"}`;
+      assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
   });
-  describe('.debug', function() {
-  	it('test debug function', function() {
-  	  logObj.debug("testlogdebug");
-  	  var expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.Debug + "\", \"title\": \"testlogdebug\"}";
-  	  return assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
-  });
-  	return it('test debugD function', function() {
-  	  logObj.debugD("testlogdebug", {"key1":"val1","key2":"val2"});
-  	  var expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.Debug + "\", \"title\": \"testlogdebug\",\"key1\": \"val1\", \"key2\": \"val2\"}";
-  	  return assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
-  });
-  });
-
-  describe('.info', function() {
-  	it('test info function', function() {
-  	  logObj.info("testloginfo");
-  	  var expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.Info + "\", \"title\": \"testloginfo\"}";
-  	  return assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
-  });
-  	return it('test infoD function', function() {
-  	  logObj.infoD("testloginfo", {"key1":"val1","key2":"val2"});
-
-  	  var expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.Info + "\", \"title\": \"testloginfo\",\"key1\": \"val1\", \"key2\": \"val2\"}";
-  	  return assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
-  });
+  describe(".debug", () => {
+    it("test debug function", () => {
+      logObj.debug("testlogdebug");
+      const expected = `{"source": "logger-tester", "level": "${kayvee.logger.Debug}", "title": "testlogdebug"}`;
+      assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
+    });
+    it("test debugD function", () => {
+      logObj.debugD("testlogdebug", {key1: "val1", key2: "val2"});
+      const expected = `{"source": "logger-tester", "level": "${kayvee.logger.Debug}", "title": "testlogdebug","key1": "val1", "key2": "val2"}`;
+      assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
+    });
   });
 
-  describe('.warning', function() {
-  	it('test warn function', function() {
-  	  logObj.warn("testlogwarning");
-  	  var expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.Warning + "\", \"title\": \"testlogwarning\"}";
-  	  return assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
-  });
-  	return it('test warnD function', function() {
-  	  logObj.warnD("testlogwarning", {"key1":"val1","key2":"val2"});
-  	  var expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.Warning + "\", \"title\": \"testlogwarning\",\"key1\": \"val1\", \"key2\": \"val2\"}";
-  	  return assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
-  });
-  });
-
-  describe('.error', function() {
-  	it('test error function', function() {
-  	  logObj.error("testlogerror");
-  	  var expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.Error + "\", \"title\": \"testlogerror\"}";
-  	  return assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
-  });
-  	return it('test errorD function', function() {
-  	  logObj.errorD("testlogerror", {"key1":"val1","key2":"val2"});
-  	  var expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.Error + "\", \"title\": \"testlogerror\",\"key1\": \"val1\", \"key2\": \"val2\"}";
-  	  return assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
-  });
-  });
-
-  describe('.critical', function() {
-  	it('test critical function', function() {
-  	  logObj.critical("testlogcritical");
-  	  var expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.Critical + "\", \"title\": \"testlogcritical\"}";
-  	  return assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
-  });
-  	return it('test criticalD function', function() {
-  	  logObj.criticalD("testlogcritical", {"key1":"val1","key2":"val2"});
-  	  var expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.Critical + "\", \"title\": \"testlogcritical\",\"key1\": \"val1\", \"key2\": \"val2\"}";
-  	  return assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
-  });
-  });
-
-  describe('.counter', function() {
-  	it('test counter function', function() {
-  	  logObj.counter("testlogcounter");
-  	  var expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.Info + "\", \"title\": \"testlogcounter\", \"type\": \"counter\", \"value\": 1}";
-  	  return assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
-  });
-  	return it('test counterD function', function() {
-  	  logObj.counterD("testlogcounter", 2, {"key1":"val1","key2":"val2"});
-  	  var expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.Info + "\", \"title\": \"testlogcounter\",\"type\": \"counter\", \"value\": 2,\"key1\": \"val1\", \"key2\": \"val2\"}";
-  	  return assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
-  });
-  });
-
-  describe('.gauge', function() {
-  	it('test gauge function', function() {
-  	  logObj.gauge("testloggauge", 0);
-  	  var expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.Info + "\", \"title\": \"testloggauge\", \"type\": \"gauge\", \"value\": 0}";
-  	  return assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
-  });
-  	return it('test gaugeD function', function() {
-  	  logObj.gaugeD("testloggauge", 4, {"key1":"val1","key2":"val2"});
-  	  var expected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.Info + "\", \"title\": \"testloggauge\", \"type\": \"gauge\", \"value\": 4, \"key1\": \"val1\", \"key2\": \"val2\"}";
-  	  return assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
-  });
-  });
-
-  describe('.diffoutput', function() {
-    return it('output to different output functions using same logger', function() {
+  describe(".info", () => {
+    it("test info function", () => {
       logObj.info("testloginfo");
-      var infoLog = sample;
-      var output2 = "";
-      var outputFunc2 = function(text) { return output2 = text; };
+      const expected = `{"source": "logger-tester", "level": "${kayvee.logger.Info}", "title": "testloginfo"}`;
+      assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
+    });
+    it("test infoD function", () => {
+      logObj.infoD("testloginfo", {key1: "val1", key2: "val2"});
+      const expected = `{"source": "logger-tester", "level": "${kayvee.logger.Info}", "title": "testloginfo","key1": "val1", "key2": "val2"}`;
+      assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
+    });
+  });
+
+  describe(".warning", () => {
+    it("test warn function", () => {
+      logObj.warn("testlogwarning");
+      const expected = `{"source": "logger-tester", "level": "${kayvee.logger.Warning}", "title": "testlogwarning"}`;
+      assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
+    });
+    it("test warnD function", () => {
+      logObj.warnD("testlogwarning", {key1: "val1", key2: "val2"});
+      const expected = `{"source": "logger-tester", "level": "${kayvee.logger.Warning}", "title": "testlogwarning","key1": "val1", "key2": "val2"}`;
+      assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
+    });
+  });
+
+  describe(".error", () => {
+    it("test error function", () => {
+      logObj.error("testlogerror");
+      const expected = `{"source": "logger-tester", "level": "${kayvee.logger.Error}", "title": "testlogerror"}`;
+      assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
+    });
+    it("test errorD function", () => {
+      logObj.errorD("testlogerror", {key1: "val1", key2: "val2"});
+      const expected = `{"source": "logger-tester", "level": "${kayvee.logger.Error}", "title": "testlogerror","key1": "val1", "key2": "val2"}`;
+      assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
+    });
+  });
+
+  describe(".critical", () => {
+    it("test critical function", () => {
+      logObj.critical("testlogcritical");
+      const expected = `{"source": "logger-tester", "level": "${kayvee.logger.Critical}", "title": "testlogcritical"}`;
+      assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
+    });
+    it("test criticalD function", () => {
+      logObj.criticalD("testlogcritical", {key1: "val1", key2: "val2"});
+      const expected = `{"source": "logger-tester", "level": "${kayvee.logger.Critical}", "title": "testlogcritical","key1": "val1", "key2": "val2"}`;
+      assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
+    });
+  });
+
+  describe(".counter", () => {
+    it("test counter function", () => {
+      logObj.counter("testlogcounter");
+      const expected = `{"source": "logger-tester", "level": "${kayvee.logger.Info}", "title": "testlogcounter", "type": "counter", "value": 1}`;
+      assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
+    });
+    it("test counterD function", () => {
+      logObj.counterD("testlogcounter", 2, {key1: "val1", key2: "val2"});
+      const expected = `{"source": "logger-tester", "level": "${kayvee.logger.Info}", "title": "testlogcounter","type": "counter", "value": 2,"key1": "val1", "key2": "val2"}`;
+      assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
+    });
+  });
+
+  describe(".gauge", () => {
+    it("test gauge function", () => {
+      logObj.gauge("testloggauge", 0);
+      const expected = `{"source": "logger-tester", "level": "${kayvee.logger.Info}", "title": "testloggauge", "type": "gauge", "value": 0}`;
+      assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
+    });
+    it("test gaugeD function", () => {
+      logObj.gaugeD("testloggauge", 4, {key1: "val1", key2: "val2"});
+      const expected = `{"source": "logger-tester", "level": "${kayvee.logger.Info}", "title": "testloggauge", "type": "gauge", "value": 4, "key1": "val1", "key2": "val2"}`;
+      assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
+    });
+  });
+
+  describe(".diffoutput", () => {
+    it("output to different output functions using same logger", () => {
+      logObj.info("testloginfo");
+      const infoLog = sample;
+      let output2 = "";
+      const outputFunc2 = (text) => {
+        output2 = text;
+        return output2;
+      };
       logObj.setOutput(outputFunc2);
       logObj.warn("testlogwarning");
       assert.deepEqual(JSON.parse(infoLog), JSON.parse(sample));
-      return assert.notDeepEqual(JSON.parse(output2), JSON.parse(sample));
+      assert.notDeepEqual(JSON.parse(output2), JSON.parse(sample));
     });
   });
 
-  describe('.hiddenlog', function() {
-    describe('.logwarning', function() {
-      beforeEach(function() {
-        return logObj.setLogLevel(logger.Warning);
-      });
-      it('empty cases due to log level', function() {
+  describe(".hiddenlog", () => {
+    describe(".logwarning", () => {
+      beforeEach(() => logObj.setLogLevel(kayvee.logger.Warning));
+      it("empty cases due to log level", () => {
         logObj.debug("testlogdebug");
         assert.equal(sample, "");
 
         logObj.info("testloginfo");
-        return assert.equal(sample, "");
+        assert.equal(sample, "");
       });
-      return it('not empty cases due to log level', function() {
+      it("not empty cases due to log level", () => {
         logObj.warn("testlogwarning");
         assert.notDeepEqual(JSON.parse(sample), "");
 
@@ -191,14 +192,14 @@ describe('logger_test', function() {
         assert.notDeepEqual(JSON.parse(sample), "");
 
         logObj.critical("testlogcritical");
-        return assert.notDeepEqual(JSON.parse(sample), "");
+        assert.notDeepEqual(JSON.parse(sample), "");
       });
     });
-    return describe('.logcritical', function() {
-      beforeEach(function() {
-        return logObj.setLogLevel(logger.Critical);
+    return describe(".logcritical", () => {
+      beforeEach(() => {
+        logObj.setLogLevel(kayvee.logger.Critical);
       });
-      it('empty cases due to log level', function() {
+      it("empty cases due to log level", () => {
         logObj.debug("testlogdebug");
         assert.equal(sample, "");
 
@@ -209,48 +210,52 @@ describe('logger_test', function() {
         assert.equal(sample, "");
 
         logObj.error("testlogerror");
-        return assert.equal(sample, "");
+        assert.equal(sample, "");
       });
-      return it('not empty cases due to log level', function() {
+      it("not empty cases due to log level", () => {
         logObj.critical("testlogcritical");
-        return assert.notDeepEqual(JSON.parse(sample), "");
+        assert.notDeepEqual(JSON.parse(sample), "");
       });
     });
   });
 
-  describe('.diffformat', function() {
-    return it('use a different formatter than KV', function() {
-      var testFormatter = function(data) { return "\"This is a test\""; };
+  describe(".diffformat", () => {
+    it("use a different formatter than KV", () => {
+      const testFormatter = () => "\"This is a test\"";
       logObj.setFormatter(testFormatter);
       logObj.warn("testlogwarning");
-      return assert.deepEqual(JSON.parse(sample), "This is a test");
+      assert.deepEqual(JSON.parse(sample), "This is a test");
     });
   });
 
-  return describe('.multipleloggers', function() {
-    before(function() {
-      return logObj2 = new logger("logger-tester2");
+  return describe(".multipleloggers", () => {
+    before(() => {
+      logObj2 = new kayvee.logger("logger-tester2");
+      return logObj2;
     });
-    it('log to same output buffer', function() {
+    it("log to same output buffer", () => {
       logObj2.setOutput(outputFunc);
       logObj.warn("testlogwarning");
-      var output1 = sample;
+      const output1 = sample;
       logObj2.info("testloginfo");
-      return assert.notDeepEqual(JSON.parse(sample), JSON.parse(output1));
+      assert.notDeepEqual(JSON.parse(sample), JSON.parse(output1));
     });
 
-    return it('log to different output buffer', function() {
-      var output2 = "";
-      var outputFunc2 = function(text) { return output2 = text; };
+    it("log to different output buffer", () => {
+      let output2 = "";
+      const outputFunc2 = (text) => {
+        output2 = text;
+        return output2;
+      };
       logObj2.setOutput(outputFunc2);
       logObj.warn("testlogwarning");
       logObj2.info("testloginfo");
 
-      var loggerExpected = "{\"source\": \"logger-tester\", \"level\": \"" + logger.Warning + "\", \"title\": \"testlogwarning\"}";
+      const loggerExpected = `{"source": "logger-tester", "level": "${kayvee.logger.Warning}", "title": "testlogwarning"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(loggerExpected));
 
-      var logger2Expected = "{\"source\": \"logger-tester2\", \"level\": \"" + logger.Info + "\", \"title\": \"testloginfo\"}";
-      return assert.deepEqual(JSON.parse(output2), JSON.parse(logger2Expected));
+      const logger2Expected = `{"source": "logger-tester2", "level": "${kayvee.logger.Info}", "title": "testloginfo"}`;
+      assert.deepEqual(JSON.parse(output2), JSON.parse(logger2Expected));
     });
   });
 });


### PR DESCRIPTION
Add dev-dependency: eslint-airbnb-dev

Right now linting is NOT enforced in tests. Should it always run? 

There are a lot of linting errors that would need to be fixed first, so I could try to address those in this PR or provide a workaround like making sure the number of linting errors doesn't increase.