### PR TITLE
Infra 1595 middleware fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,13 @@ Kayvee includes logging middleware, compatible with expressJS.
 The middleware can be added most simply via
 
 ```js
-var kayvee = require('kayvee')
+var kayvee = require('kayvee');
 
-var app = express()
-app.use(kayvee.middleware())
+var app = express();
+app.use(kayvee.middleware({"source":"my-app"));
 ```
 
-It also supports user configuration via an `options` object.
+It also supports additional user configuration via an `options` object.
 It prints the values of the headers or the results of the handlers.
 If a value is `undefined`, the key will not be printed.
 
@@ -161,14 +161,15 @@ For example, the below snippet causes the `X-Request-Id` request header and a pa
 
 
 ```js
-var kayvee = require('kayvee')
+var kayvee = require('kayvee');
 
-var app = express()
+var app = express();
 var options = {
-    headers: ['X-Request-Id'],
+    source: "my-app",
+    headers: ["x-request-id"],
     handlers: [
         (request, response) => {"some_id": request.params.some_id});
-    ]
-}
-app.use(kayvee.middleware(options))
+    ],
+};
+app.use(kayvee.middleware(options));
 ```

--- a/README.md
+++ b/README.md
@@ -146,8 +146,10 @@ var app = express();
 app.use(kayvee.middleware({"source":"my-app"));
 ```
 
-It also supports additional user configuration via an `options` object.
-It prints the values of the headers or the results of the handlers.
+Note that `source` is a required field, since it clarifies which application is emitting the logs.
+
+The middleware also supports further user configuration via the `options` object.
+It prints the values of `headers` or the results of `handlers`.
 If a value is `undefined`, the key will not be printed.
 
 - `headers`

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -186,4 +186,8 @@ var formatLine = (options_arg) => {
  * @public
  */
 
-module.exports = (clever_options, morgan_options) => morgan(formatLine(clever_options), morgan_options);
+if (process.env.NODE_ENV === "test") {
+  module.exports = (clever_options, morgan_options) => morgan(formatLine(clever_options), morgan_options);
+} else {
+  module.exports = (clever_options) => morgan(formatLine(clever_options), {stream: process.stderr});
+}

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -75,10 +75,8 @@ function getIp(req) {
 function getLogLevel(req, res) {
   const statusCode = res.statusCode;
   let result;
-  if (statusCode >= 500) {
+  if (statusCode >= 499) {
     result = kayveeLogger.Error;
-  } else if (statusCode >= 400) {
-    result = kayveeLogger.Warning;
   } else {
     result = kayveeLogger.Info;
   }

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -4,6 +4,7 @@
  */
 
 var kayvee = require("../lib/kayvee");
+var kayveeLogger = require("../lib/logger/logger");
 var morgan = require("morgan");
 var _ = require("underscore");
 
@@ -68,6 +69,22 @@ function getIp(req) {
   return req.ip || remoteAddress;
 }
 
+/**
+ * Log level
+ */
+function getLogLevel(req, res) {
+  var statusCode = res.statusCode;
+  var result;
+  if (statusCode >= 500) {
+    result = kayveeLogger.Error;
+  } else if (statusCode >= 400) {
+    result = kayveeLogger.Warning;
+  } else {
+    result = kayveeLogger.Info;
+  }
+  return result;
+}
+
 /*
  * Default handlers
  */
@@ -86,6 +103,8 @@ var defaultHandlers = [
   (req, res) => ({"status-code": res.statusCode}),
   // Ip address
   (req) => ({ip: getIp(req)}),
+  // Log level
+  (req, res) => ({level: getLogLevel(req, res)}),
 ];
 
 /*

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -108,7 +108,7 @@ var defaultHandlers = [
   // Log level
   (req, res) => ({level: getLogLevel(req, res)}),
   // Source
-  () => ({source: "kayvee"}),
+  // -> Gets passed in among `options` during library initialization
   // Title
   () => ({title: "request-info"}),
 ];
@@ -140,6 +140,11 @@ var defaultHandlers = [
 var formatLine = (options_arg) => {
   var options = options_arg || {};
 
+  // `source` is the one required field
+  if (!options.source) {
+    throw (Error("Missing required config for 'source' in Kayvee middleware 'options'"));
+  }
+
   return (tokens, req, res) => {
     // Build a dict of data to log
     var data = {};
@@ -159,6 +164,7 @@ var formatLine = (options_arg) => {
 
     // Allow user to override `base_handlers`; provide sane default set of handlers
     var base_handlers = options.base_handlers || defaultHandlers;
+    base_handlers = base_handlers.concat([() => ({source: options.source})]);
 
     // Execute custom-handlers THEN base-handlers
     var all_handlers = custom_handlers.concat(base_handlers);

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -73,8 +73,8 @@ function getIp(req) {
  * Log level
  */
 function getLogLevel(req, res) {
-  var statusCode = res.statusCode;
-  var result;
+  const statusCode = res.statusCode;
+  let result;
   if (statusCode >= 500) {
     result = kayveeLogger.Error;
   } else if (statusCode >= 400) {

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -103,8 +103,14 @@ var defaultHandlers = [
   (req, res) => ({"status-code": res.statusCode}),
   // Ip address
   (req) => ({ip: getIp(req)}),
+
+  // Kayvee's reserved fields
   // Log level
   (req, res) => ({level: getLogLevel(req, res)}),
+  // Source
+  () => ({source: "kayvee"}),
+  // Title
+  () => ({title: "request-info"}),
 ];
 
 /*

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -101,14 +101,16 @@ var defaultHandlers = [
   (req, res) => ({"status-code": res.statusCode}),
   // Ip address
   (req) => ({ip: getIp(req)}),
+  // Via -- what library/code produced this log?
+  () => ({via: "kayvee-middleware"}),
 
   // Kayvee's reserved fields
   // Log level
   (req, res) => ({level: getLogLevel(req, res)}),
-  // Source
+  // Source -- which app emitted this log?
   // -> Gets passed in among `options` during library initialization
   // Title
-  () => ({title: "request-info"}),
+  () => ({title: "request-finished"}),
 ];
 
 /*

--- a/test/middleware.ts
+++ b/test/middleware.ts
@@ -90,6 +90,7 @@ _.each(["http", "express"], (serverType) => {
           "response-time": 99999,
           "status-code": 200,
           ip: "::ffff:127.0.0.1",
+          level: "info",
         });
         assert.equal(masked, expected);
         return done();
@@ -125,6 +126,7 @@ _.each(["http", "express"], (serverType) => {
           "response-time": 99999,
           "status-code": 200,
           ip: "::ffff:127.0.0.1",
+          level: "info",
         });
         assert.equal(masked, expected);
         return done();
@@ -164,6 +166,7 @@ _.each(["http", "express"], (serverType) => {
           "response-time": 99999,
           "status-code": 200,
           ip: "::ffff:127.0.0.1",
+          level: "info",
         });
         assert.equal(masked, expected);
         return done();
@@ -202,6 +205,7 @@ _.each(["http", "express"], (serverType) => {
           "response-time": 99999,
           "status-code": 200,
           ip: "::ffff:127.0.0.1",
+          level: "info",
         });
         assert.equal(masked, expected);
         return done();
@@ -241,6 +245,7 @@ _.each(["http", "express"], (serverType) => {
           "response-time": 99999,
           "status-code": 200,
           ip: "::ffff:127.0.0.1",
+          level: "info",
         });
         assert.equal(masked, expected);
         return done();

--- a/test/middleware.ts
+++ b/test/middleware.ts
@@ -100,8 +100,9 @@ _.each(["http", "express"], (serverType) => {
           "response-time": 99999,
           "status-code": 200,
           ip: "::ffff:127.0.0.1",
+          via: "kayvee-middleware",
           level: "info",
-          title: "request-info",
+          title: "request-finished",
           source: "test-app",
         });
         assert.equal(masked, expected);
@@ -138,8 +139,9 @@ _.each(["http", "express"], (serverType) => {
           "response-time": 99999,
           "status-code": 200,
           ip: "::ffff:127.0.0.1",
+          via: "kayvee-middleware",
           level: "info",
-          title: "request-info",
+          title: "request-finished",
           source: "test-app",
         });
         assert.equal(masked, expected);
@@ -181,8 +183,9 @@ _.each(["http", "express"], (serverType) => {
           "response-time": 99999,
           "status-code": 200,
           ip: "::ffff:127.0.0.1",
+          via: "kayvee-middleware",
           level: "info",
-          title: "request-info",
+          title: "request-finished",
           source: "test-app",
         });
         assert.equal(masked, expected);
@@ -223,8 +226,9 @@ _.each(["http", "express"], (serverType) => {
           "response-time": 99999,
           "status-code": 200,
           ip: "::ffff:127.0.0.1",
+          via: "kayvee-middleware",
           level: "info",
-          title: "request-info",
+          title: "request-finished",
           source: "test-app",
         });
         assert.equal(masked, expected);
@@ -266,8 +270,9 @@ _.each(["http", "express"], (serverType) => {
           "response-time": 99999,
           "status-code": 200,
           ip: "::ffff:127.0.0.1",
+          via: "kayvee-middleware",
           level: "info",
-          title: "request-info",
+          title: "request-finished",
           source: "test-app",
         });
         assert.equal(masked, expected);

--- a/test/middleware.ts
+++ b/test/middleware.ts
@@ -91,6 +91,8 @@ _.each(["http", "express"], (serverType) => {
           "status-code": 200,
           ip: "::ffff:127.0.0.1",
           level: "info",
+          source: "kayvee",
+          title: "request-info",
         });
         assert.equal(masked, expected);
         return done();
@@ -127,6 +129,8 @@ _.each(["http", "express"], (serverType) => {
           "status-code": 200,
           ip: "::ffff:127.0.0.1",
           level: "info",
+          source: "kayvee",
+          title: "request-info",
         });
         assert.equal(masked, expected);
         return done();
@@ -167,6 +171,8 @@ _.each(["http", "express"], (serverType) => {
           "status-code": 200,
           ip: "::ffff:127.0.0.1",
           level: "info",
+          source: "kayvee",
+          title: "request-info",
         });
         assert.equal(masked, expected);
         return done();
@@ -206,6 +212,8 @@ _.each(["http", "express"], (serverType) => {
           "status-code": 200,
           ip: "::ffff:127.0.0.1",
           level: "info",
+          source: "kayvee",
+          title: "request-info",
         });
         assert.equal(masked, expected);
         return done();
@@ -246,6 +254,8 @@ _.each(["http", "express"], (serverType) => {
           "status-code": 200,
           ip: "::ffff:127.0.0.1",
           level: "info",
+          source: "kayvee",
+          title: "request-info",
         });
         assert.equal(masked, expected);
         return done();

--- a/test/middleware.ts
+++ b/test/middleware.ts
@@ -78,6 +78,16 @@ function createServer(server_type, clever_options, morgan_options, fn) {
 
 _.each(["http", "express"], (serverType) => {
   describe(`middleware for *${serverType}* server`, () => {
+    it("should throw error on intialization if `source` not set in `options`", (done) => {
+      var options = {};
+      var erroringServer = () => createServer(serverType, options, null, (req, res, next) => {
+        res.setHeader("some-header", "some-header-value");
+        next();
+      });
+      assert.throws(erroringServer, Error, "Expected an error to be thrown");
+      return done();
+    });
+
     it("should pass default fields", (done) => {
       var cb = afterTest(2, (err, res, line) => {
         if (err) { return done(err); }
@@ -91,8 +101,8 @@ _.each(["http", "express"], (serverType) => {
           "status-code": 200,
           ip: "::ffff:127.0.0.1",
           level: "info",
-          source: "kayvee",
           title: "request-info",
+          source: "test-app",
         });
         assert.equal(masked, expected);
         return done();
@@ -102,7 +112,7 @@ _.each(["http", "express"], (serverType) => {
         cb(null, null, line);
       });
 
-      var options = undefined;
+      var options = {source: "test-app"};
 
       var server = createServer(serverType, options, {stream}, (req, res, next) => {
         res.setHeader("some-header", "some-header-value");
@@ -129,8 +139,8 @@ _.each(["http", "express"], (serverType) => {
           "status-code": 200,
           ip: "::ffff:127.0.0.1",
           level: "info",
-          source: "kayvee",
           title: "request-info",
+          source: "test-app",
         });
         assert.equal(masked, expected);
         return done();
@@ -141,6 +151,7 @@ _.each(["http", "express"], (serverType) => {
       });
 
       var options = {
+        source: "test-app",
         headers: ["some-header", "another-header"],
       };
 
@@ -171,8 +182,8 @@ _.each(["http", "express"], (serverType) => {
           "status-code": 200,
           ip: "::ffff:127.0.0.1",
           level: "info",
-          source: "kayvee",
           title: "request-info",
+          source: "test-app",
         });
         assert.equal(masked, expected);
         return done();
@@ -183,6 +194,7 @@ _.each(["http", "express"], (serverType) => {
       });
 
       var options = {
+        source: "test-app",
         handlers: [
           () => ({global: 1}),
           () => ({global2: 2}),
@@ -212,8 +224,8 @@ _.each(["http", "express"], (serverType) => {
           "status-code": 200,
           ip: "::ffff:127.0.0.1",
           level: "info",
-          source: "kayvee",
           title: "request-info",
+          source: "test-app",
         });
         assert.equal(masked, expected);
         return done();
@@ -224,6 +236,7 @@ _.each(["http", "express"], (serverType) => {
       });
 
       var options = {
+        source: "test-app",
         // These values should not be logged
         headers: ["this-header-dne"],
         handlers: [
@@ -254,8 +267,8 @@ _.each(["http", "express"], (serverType) => {
           "status-code": 200,
           ip: "::ffff:127.0.0.1",
           level: "info",
-          source: "kayvee",
           title: "request-info",
+          source: "test-app",
         });
         assert.equal(masked, expected);
         return done();
@@ -266,6 +279,7 @@ _.each(["http", "express"], (serverType) => {
       });
 
       var options = {
+        source: "test-app",
         handlers: [
           // This handler should be ignored, because it has an error
           () => { throw (new Error("handler that throws an error")); },
@@ -290,6 +304,7 @@ _.each(["http", "express"], (serverType) => {
         const expected = kayvee.format({
           global: 1,
           base: 1,
+          source: "test-app",
         });
         assert.equal(masked, expected);
         return done();
@@ -300,6 +315,7 @@ _.each(["http", "express"], (serverType) => {
       });
 
       var options = {
+        source: "test-app",
         base_handlers: [
           () => ({base: 1}),
         ],
@@ -324,6 +340,7 @@ _.each(["http", "express"], (serverType) => {
         const expected = kayvee.format({
           global: 1,
           base: 1,
+          source: "test-app",
         });
         assert.equal(masked, expected);
         return done();
@@ -334,6 +351,7 @@ _.each(["http", "express"], (serverType) => {
       });
 
       var options = {
+        source: "test-app",
         base_handlers: [
           () => (1),
           () => ("a"),


### PR DESCRIPTION
Previously, we weren't logging `source`, `title`, or `level`. Now we are. `level` is determined based on the response's status code.

`source` is passed by the user among the config `options`.
It's a required field.

Updated title: `request-finished`
