### PR TITLE
clone input data before modifying

### DIFF
--- a/lib/kayvee.ts
+++ b/lib/kayvee.ts
@@ -1,4 +1,5 @@
 var _ = require("underscore");
+_.mixin(require("underscore.deep"));
 
 // Converts a map to a string space-delimited key=val pairs
 function format(data) {
@@ -7,7 +8,7 @@ function format(data) {
 
 // Similar to format, but takes additional reserved params to promote logging best-practices
 function formatLog(source = "", level = "", title = "", data = {}) {
-  let reallyData = data;
+  let reallyData = _.deepClone(data);
   if (!_.isObject(data)) {
     reallyData = {};
   }

--- a/lib/logger/logger.ts
+++ b/lib/logger/logger.ts
@@ -1,5 +1,7 @@
-var _ = require("underscore");
+var _   = require("underscore");
+_.mixin(require("underscore.deep"));
 var kv  = require("../kayvee");
+
 
 var LEVELS = {
   Debug:    "debug",
@@ -99,48 +101,56 @@ class Logger {
   }
 
   debugD(title, data) {
-    data.title = title;
-    this.logWithLevel(LEVELS.Debug, data);
+    this._logWithLevel(LEVELS.Debug, {
+      title,
+    }, data);
   }
 
   infoD(title, data) {
-    data.title = title;
-    this.logWithLevel(LEVELS.Info, data);
+    this._logWithLevel(LEVELS.Info, {
+      title,
+    }, data);
   }
 
   warnD(title, data) {
-    data.title = title;
-    this.logWithLevel(LEVELS.Warning, data);
+    this._logWithLevel(LEVELS.Warning, {
+      title,
+    }, data);
   }
 
   errorD(title, data) {
-    data.title = title;
-    this.logWithLevel(LEVELS.Error, data);
+    this._logWithLevel(LEVELS.Error, {
+      title,
+    }, data);
   }
 
   criticalD(title, data) {
-    data.title = title;
-    this.logWithLevel(LEVELS.Critical, data);
+    this._logWithLevel(LEVELS.Critical, {
+      title,
+    }, data);
   }
 
   counterD(title, value, data) {
-    data.title = title;
-    data.value = value;
-    data.type = "counter";
-    this.logWithLevel(LEVELS.Info, data);
+    this._logWithLevel(LEVELS.Info, {
+      title,
+      value,
+      type: "counter",
+    }, data);
   }
 
   gaugeD(title, value, data) {
-    data.title = title;
-    data.value = value;
-    data.type = "gauge";
-    this.logWithLevel(LEVELS.Info, data);
+    this._logWithLevel(LEVELS.Info, {
+      title,
+      value,
+      type:  "gauge",
+    }, data);
   }
 
-  logWithLevel(logLvl, data) {
+  _logWithLevel(logLvl, metadata, userdata) {
     if (LOG_LEVEL_ENUM[logLvl] < LOG_LEVEL_ENUM[this.logLvl]) {
       return;
     }
+    const data = _.extend(metadata, _(userdata).deepClone());
     data.level = logLvl;
     _.defaults(data, this.globals);
     this.logWriter(this.formatter(data));

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "morgan": "^1.7.0",
     "split": "^1.0.0",
     "supertest": "^1.2.0",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "underscore.deep": "^0.5.1"
   },
   "devDependencies": {
     "babel-eslint": "^6.0.2",
@@ -24,8 +25,7 @@
     "mocha": "~1.17.0",
     "ts-node": "^0.7.1",
     "tslint": "^3.7.4",
-    "typescript": "^1.8.9",
-    "underscore.deep": "^0.5.1"
+    "typescript": "^1.8.9"
   },
   "scripts": {
     "test": "make -Br test",

--- a/test/logger_test.ts
+++ b/test/logger_test.ts
@@ -176,6 +176,36 @@ describe("logger_test", () => {
     });
   });
 
+  describe(".nomodifydata", () => {
+    before(() => {
+      logObj.setOutput(outputFunc);
+    });
+    it("does not modify data", () => {
+      const data = {
+        str: "modify",
+        obj: {
+          key: "value",
+        },
+        fun: "boo",
+      };
+      // not using deepClone since that's what we are
+      // somewhat testing
+      const dataCopy = {
+        str: "modify",
+        obj: {
+          key: "value",
+        },
+        fun: "boo",
+      };
+      const output = ['{"title":"testInfoWithData",',
+        '"str":"modify","obj":{"key":"value"},"fun":"boo",',
+        '"level":"info","source":"logger-tester"}'].join("");
+      logObj.infoD("testInfoWithData", data);
+      assert.deepEqual(data, dataCopy);
+      assert.equal(sample, output);
+    });
+  });
+
   describe(".hiddenlog", () => {
     describe(".logwarning", () => {
       beforeEach(() => logObj.setLogLevel(KayveeLogger.Warning));


### PR DESCRIPTION
* if clients send an object that is reused in other contexts they would have additional properties.