### PR TITLE
inject deploy env to kayvee logs

### DIFF
--- a/lib/kayvee.ts
+++ b/lib/kayvee.ts
@@ -3,6 +3,9 @@ _.mixin(require("underscore.deep"));
 
 // Converts a map to a string space-delimited key=val pairs
 function format(data) {
+  if (process.env.DEPLOY_ENV != null) {
+    return JSON.stringify(_.extend({deploy_env: process.env.DEPLOY_ENV}, data));
+  }
   return JSON.stringify(data);
 }
 

--- a/test/kayvee.ts
+++ b/test/kayvee.ts
@@ -7,11 +7,29 @@ var fs = require("fs");
 describe("kayvee", () => {
   const tests = JSON.parse(fs.readFileSync("test/tests.json"));
   describe(".format", () => {
-    _.each(tests.format, (spec) => {
-      it(spec.title, () => {
-        const actual = kv.format(spec.input.data);
-        const expected = spec.output;
-        assert.deepEqual(JSON.parse(actual), JSON.parse(expected));
+    describe("without deploy_env", () => {
+      _.each(tests.format, (spec) => {
+        it(spec.title, () => {
+          const actual = kv.format(spec.input.data);
+          const expected = spec.output;
+          assert.deepEqual(JSON.parse(actual), JSON.parse(expected));
+        });
+      });
+    });
+    describe("with deploy_env", () => {
+      before(() => {
+        process.env.DEPLOY_ENV = "testing";
+      });
+      after(() => {
+        delete process.env.DEPLOY_ENV;
+      });
+      _.each(tests.format, (spec) => {
+        it(spec.title, () => {
+          const actual = kv.format(spec.input.data);
+          const expected = spec.output;
+          assert.deepEqual(JSON.parse(actual), _.extend({deploy_env: "testing"},
+                                                        JSON.parse(expected)));
+        });
       });
     });
   });


### PR DESCRIPTION
So that kayvee logs can include the deploy environment automatically (needed for metrics to distinguish on env)