### PR TITLE
Refactor json-schema to validate a full kv-config object

### DIFF
--- a/lib/router/schema_definitions.json
+++ b/lib/router/schema_definitions.json
@@ -1,113 +1,119 @@
 {
-  "description": "Last modified: 10/14/2016",
-  "routes": {
-    "type": "object",
-    "minProperties": 1,
-    "patternProperties": {
-      "^[^%\\${}]+$": { "$ref": "#/ruleSchema" }
-    }
+  "description": "Last modified: 11/08/2016",
+  "required": ["routes"],
+  "properties": {
+    "routes": { "$ref": "#/definitions/routes" }
   },
-  "rule": {
-    "title": "Rule",
-    "type": "object",
-    "required": ["matchers", "output"],
-    "additionalProperties": false,
-    "properties": {
-      "matchers": { "$ref": "#/definitions/matchers" },
-      "output": { "$ref": "#/definitions/output" }
-    }
-  },
-  "matchers": {
-    "type": "object",
-    "minProperties": 1,
-    "additionalProperties": false,
-    "patternProperties": {
-      "^[^%\\${}]+$": { "$ref": "#/definitions/flatValueArr" }
-    }
-  },
-  "output": {
-    "type": "object",
-    "oneOf": [
-      { "$ref": "#/definitions/metricsOutput" },
-      { "$ref": "#/definitions/alertsOutput" },
-      { "$ref": "#/definitions/analyticsOutput" },
-      { "$ref": "#/definitions/notificationsOutput" }
-    ]
-  },
-  "metricsOutput": {
-    "title": "Metrics Output",
-    "type": "object",
-    "additionalProperties": false,
-    "required": ["type", "series", "dimensions"],
-    "properties": {
-      "type": {
-        "type": "string",
-        "pattern": "^metrics$"
-      },
-      "series": { "$ref": "#/definitions/envVarSubstValue" },
-      "dimensions": { "$ref": "#/definitions/flatValueArr" }
-    }
-  },
-  "alertsOutput": {
-    "type": "object",
-    "additionalProperties": false,
-    "required": ["type", "series", "dimensions", "stat_type"],
-    "properties": {
-      "type": {
-        "type": "string",
-        "pattern": "^alerts$"
-      },
-      "series": { "$ref": "#/definitions/envVarSubstValue" },
-      "dimensions": { "$ref": "#/definitions/flatValueArr" },
-      "stat_type": {
-        "type": "string",
-        "enum": ["counter", "gauge"]
+  "definitions": {
+    "routes": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[^%\\${}]+$": { "$ref": "#/definitions/rule" }
       }
+    },
+    "rule": {
+      "title": "Rule",
+      "type": "object",
+      "required": ["matchers", "output"],
+      "additionalProperties": false,
+      "properties": {
+        "matchers": { "$ref": "#/definitions/matchers" },
+        "output": { "$ref": "#/definitions/output" }
+      }
+    },
+    "matchers": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[^%\\${}]+$": { "$ref": "#/definitions/flatValueArr" }
+      }
+    },
+    "output": {
+      "type": "object",
+      "oneOf": [
+        { "$ref": "#/definitions/metricsOutput" },
+        { "$ref": "#/definitions/alertsOutput" },
+        { "$ref": "#/definitions/analyticsOutput" },
+        { "$ref": "#/definitions/notificationsOutput" }
+      ]
+    },
+    "metricsOutput": {
+      "title": "Metrics Output",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "series", "dimensions"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "pattern": "^metrics$"
+        },
+        "series": { "$ref": "#/definitions/envVarSubstValue" },
+        "dimensions": { "$ref": "#/definitions/flatValueArr" }
+      }
+    },
+    "alertsOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "series", "dimensions", "stat_type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "pattern": "^alerts$"
+        },
+        "series": { "$ref": "#/definitions/envVarSubstValue" },
+        "dimensions": { "$ref": "#/definitions/flatValueArr" },
+        "stat_type": {
+          "type": "string",
+          "enum": ["counter", "gauge"]
+        }
+      }
+    },
+    "analyticsOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "series"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "pattern": "^analytics$"
+        },
+        "series": { "$ref": "#/definitions/envVarSubstValue" }
+      }
+    },
+    "notificationsOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "channel", "icon", "message", "user"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "pattern": "^notifications$"
+        },
+        "channel": { "$ref": "#/definitions/envVarSubstValue" },
+        "icon": { "$ref": "#/definitions/envVarSubstValue" },
+        "message": { "$ref": "#/definitions/kvSubstValue" },
+        "user": { "$ref": "#/definitions/envVarSubstValue" }
+      }
+    },
+    "flatValue": {
+      "type": "string",
+      "pattern": "^[^%\\${}]+$"
+    },
+    "flatValueArr": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/definitions/flatValue" }
+    },
+    "envVarSubstValue": {
+      "type": "string",
+      "pattern": "^([^\\$%{}]|\\${[^%\\${}]+})+$"
+    },
+    "kvSubstValue": {
+      "type": "string",
+      "pattern": "^([^\\$%{}]|\\${[^%\\${}]+}|%{[^%\\${}]+})+$"
     }
-  },
-  "analyticsOutput": {
-    "type": "object",
-    "additionalProperties": false,
-    "required": ["type", "series"],
-    "properties": {
-      "type": {
-        "type": "string",
-        "pattern": "^analytics$"
-      },
-      "series": { "$ref": "#/definitions/envVarSubstValue" }
-    }
-  },
-  "notificationsOutput": {
-    "type": "object",
-    "additionalProperties": false,
-    "required": ["type", "channel", "icon", "message", "user"],
-    "properties": {
-      "type": {
-        "type": "string",
-        "pattern": "^notifications$"
-      },
-      "channel": { "$ref": "#/definitions/envVarSubstValue" },
-      "icon": { "$ref": "#/definitions/envVarSubstValue" },
-      "message": { "$ref": "#/definitions/kvSubstValue" },
-      "user": { "$ref": "#/definitions/envVarSubstValue" }
-    }
-  },
-  "flatValue": {
-    "type": "string",
-    "pattern": "^[^%\\${}]+$"
-  },
-  "flatValueArr": {
-    "type": "array",
-    "minItems": 1,
-    "uniqueItems": true,
-    "items": { "$ref": "#/definitions/flatValue" }
-  },
-  "envVarSubstValue": {
-    "type": "string",
-    "pattern": "^([^\\$%{}]|\\${[^%\\${}]+})+$"
-  },
-  "kvSubstValue": {
-    "type": "string",
-    "pattern": "^([^\\$%{}]|\\${[^%\\${}]+}|%{[^%\\${}]+})+$"
   }
 }

--- a/test/router.ts
+++ b/test/router.ts
@@ -64,11 +64,9 @@ routes:
 
       for (const invalidVal of ["5", "true", "[]", "{}"]) {
         const invalidConf = confTmpl(invalidVal);
-        assert.throws(() => actual._loadConfigString(invalidConf),
-                      /^Error: Rule "non-string-values" matchers: instance.no-numbers\[0\] is not of a type\(s\) string$/);
+        assert.throws(() => actual._loadConfigString(invalidConf));
       }
-      assert.throws(() => actual._loadConfigString(confTmpl("\"\"")),
-                    /^Error: Rule "non-string-values" matchers: instance.no-numbers\[0\] does not match pattern/);
+      assert.throws(() => actual._loadConfigString(confTmpl("\"\"")));
       return;
     });
 
@@ -89,8 +87,7 @@ routes:
       assert.doesNotThrow(() => actual._loadConfigString(validConf));
 
       const invalidConf = confTmpl("\"repeated\", \"repeated\", \"name\"");
-      assert.throws(() => actual._loadConfigString(invalidConf),
-                   /^Error: Rule "sloppy" matchers: instance.title contains duplicate item$/);
+      assert.throws(() => actual._loadConfigString(invalidConf));
     });
 
     it("requires correct types in outputs", () => {
@@ -111,12 +108,10 @@ routes:
       assert.doesNotThrow(() => actual._loadConfigString(validConf));
 
       const invalidConf0 = confTmpl("[\"my-series\"]", "[\"dim1\", \"dim2\"]");
-      assert.throws(() => actual._loadConfigString(invalidConf0),
-                   /^Error: Rule "wrong" output: instance.series is not of a type\(s\) string$/);
+      assert.throws(() => actual._loadConfigString(invalidConf0));
 
       const invalidConf1 = confTmpl("\"my-series\"", "\"dim1\"");
-      assert.throws(() => actual._loadConfigString(invalidConf1),
-                   /^Error: Rule "wrong" output: instance.dimensions is not of a type\(s\) array$/);
+      assert.throws(() => actual._loadConfigString(invalidConf1));
     });
 
     it("requires all keys in outputs", () => {
@@ -137,8 +132,7 @@ routes:
       assert.doesNotThrow(() => actual._loadConfigString(validConf));
 
       const invalidConf = confTmpl("");
-      assert.throws(() => actual._loadConfigString(invalidConf),
-                   /^Error: Rule "wrong" output: instance requires property "series"$/);
+      assert.throws(() => actual._loadConfigString(invalidConf));
     });
 
     it("doesn't allow extra keys", () => {
@@ -161,8 +155,105 @@ routes:
       const invalidConf = confTmpl(`
       series: "whatever"
       something-else: "hi there"`);
-      assert.throws(() => actual._loadConfigString(invalidConf),
-                   /^Error: Rule "wrong" output: instance additionalProperty "something-else" exists in instance when not allowed$/);
+      assert.throws(() => actual._loadConfigString(invalidConf));
+    });
+
+    it("errors on type-os", () => {
+      const actual = new router.Router();
+      let config;
+
+      config = `
+route: # Shouldn't routes (plural)
+  non-string-values:
+    matchers:
+      errors: [ "type-o" ]
+    output:
+      type: "analytics"
+      series: "fun"
+`;
+      assert.throws(() => actual._loadConfigString(config));
+
+      config = `
+routes:
+  non-string-values:
+    matcher: # Shouldn't matches (plural)
+      errors: [ "type-o" ]
+    output:
+      type: "analytics"
+      series: "fun"
+`;
+      assert.throws(() => actual._loadConfigString(config));
+
+      config = `
+routes:
+  $non-string-values: # Invalid rule name
+    matchers:
+      errors: [ "type-o" ]
+    output:
+      type: "analytics"
+      series: "fun"
+`;
+      assert.throws(() => actual._loadConfigString(config));
+
+      config = `
+routes:
+  $non-string-values: # Invalid rule name
+    matchers:
+      errors: [ "type-o" ]
+    outputs: # Should be output (signular)
+      type: "analytics"
+      series: "fun"
+`;
+      assert.throws(() => actual._loadConfigString(config));
+    });
+
+    it("errors on type-os", () => {
+      const actual = new router.Router();
+      let config;
+
+      config = `
+route: # Shouldn't routes (plural)
+  non-string-values:
+    matchers:
+      errors: [ "type-o" ]
+    output:
+      type: "analytics"
+      series: "fun"
+`;
+      assert.throws(() => actual._loadConfigString(config));
+
+      config = `
+routes:
+  non-string-values:
+    matcher: # Shouldn't matches (plural)
+      errors: [ "type-o" ]
+    output:
+      type: "analytics"
+      series: "fun"
+`;
+      assert.throws(() => actual._loadConfigString(config));
+
+      config = `
+routes:
+  $non-string-values: # Invalid rule name
+    matchers:
+      errors: [ "type-o" ]
+    output:
+      type: "analytics"
+      series: "fun"
+`;
+      assert.throws(() => actual._loadConfigString(config));
+
+      config = `
+routes:
+  $non-string-values: # Invalid rule name
+    matchers:
+      errors: [ "type-o" ]
+    outputs: # Should be output (signular)
+      type: "analytics"
+      series: "fun"
+`;
+      assert.throws(() => actual._loadConfigString(config));
     });
   });
 


### PR DESCRIPTION
The following errors should now be found:

- Top level prop is "route" instead of "routes"
- A rule has a "$", "%", "{", or "}"
- A rule has "match" instead of "matches"
- A rule has "outputs" instead of "output"

Also re-syncs json-schema with kayvee-go