### PR TITLE
KV mock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build: clean
 	cp ./lib/router/schema_definitions.json ./build/lib/router/
 	cp ./package.json ./build/
 
-test: lint tests.json $(TESTS)
+test: lint test/tests.json $(TESTS)
 
 $(TESTS):
 	_DEPLOY_ENV=testing DEBUG=us:progress NODE_ENV=test node_modules/mocha/bin/mocha --require ts-node/register --timeout 60000 test/$@.ts
@@ -34,5 +34,5 @@ lint:
 	./node_modules/.bin/tslint $(TS_FILES)
 	./node_modules/.bin/eslint $(TS_FILES)
 
-tests.json:
+test/tests.json:
 	wget https://raw.githubusercontent.com/Clever/kayvee/master/tests.json -O test/tests.json

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ module.exports = (cb) => {
         // Output structured data
         log.infoD("DataResults", {"key": "value"}); // Sends slack message
 
-        // You can use the M alias for your key value pairs
+        // You can use an object to send arbitrary key value pairs
         log.infoD("DataResults", {"shorter": "line"});
 
         cb(null);

--- a/README.md
+++ b/README.md
@@ -57,17 +57,13 @@ module.exports = (cb) => {
     // Simple debugging
     log.debug("Service has started");
 
-    // Make a query and log its length
-    let query_start = Date.now();
-    log.gauge("QueryTime", Date.now() - query_start);
-
     // Do something async
     setImmediate(() => {
         // Output structured data
         log.infoD("DataResults", {"key": "value"}); // Sends slack message
 
         // You can use an object to send arbitrary key value pairs
-        log.infoD("DataResults", {"shorter": "line"});
+        log.infoD("DataResults", {"shorter": "line"}); // will NOT send a slack message
 
         cb(null);
     });
@@ -89,7 +85,10 @@ routes:
       user: "Flight Tracker"
 ```
 
-### Testings
+### Testing
+
+To ensure that your log-routing rules are correct, use `mockRouting` to temporarily mock out kayvee.  The mock kayvee will record which rules and how often they were matched.
+
 
 ```js
 // main-test.js

--- a/benchmarks/routing.js
+++ b/benchmarks/routing.js
@@ -16,9 +16,18 @@ let basicRouting = new kv.logger("perf", kv.logger.LEVELS.Debug, (noop) => "", (
 let pathoRouting = new kv.logger("perf", kv.logger.LEVELS.Debug, (noop) => "", (noop) => "");
 let realRouting = new kv.logger("perf", kv.logger.LEVELS.Debug, (noop) => "", (noop) => "");
 
-basicRouting.setRoutingConfig(dataDir + "kvconfig-basic.yml");
-pathoRouting.setRoutingConfig(dataDir + "kvconfig-pathological.yml");
-realRouting.setRoutingConfig(dataDir + "kvconfig-realistic.yml");
+let basicRouter = new kv.router.Router();
+basicRouter.loadConfig(dataDir + "kvconfig-basic.yml");
+
+let pathoRouter = new kv.router.Router();
+pathoRouter.loadConfig(dataDir + "kvconfig-pathological.yml");
+
+let realRouter = new kv.router.Router();
+realRouter.loadConfig(dataDir + "kvconfig-realistic.yml");
+
+basicRouting.setRouter(basicRouter);
+pathoRouting.setRouter(pathoRouter);
+realRouting.setRouter(realRouter);
 
 suite
 	// No routing

--- a/index.js
+++ b/index.js
@@ -3,3 +3,4 @@ module.exports.logger = require("./build/lib/logger/logger");
 module.exports.router = require("./build/lib/router");
 module.exports.middleware = require('./build/lib/middleware')
 module.exports.setGlobalRouting = module.exports.logger.setGlobalRouting;
+module.exports.mockRouting = module.exports.logger.mockRouting;

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
 module.exports = require("./build/lib/kayvee");
 module.exports.logger = require("./build/lib/logger/logger");
+module.exports.router = require("./build/lib/router");
 module.exports.middleware = require('./build/lib/middleware')
+module.exports.setGlobalRouting = module.exports.logger.setGlobalRouting;

--- a/lib/logger/logger.ts
+++ b/lib/logger/logger.ts
@@ -177,11 +177,12 @@ class Logger {
 module.exports = Logger;
 module.exports.setGlobalRouting = setGlobalRouting;
 module.exports.mockRouting = (cb) => {
-  if((Logger.prototype._logWithLevel as any).isMocked) {
+  const _logWithLevel: any = Logger.prototype._logWithLevel;
+
+  if (_logWithLevel.isMocked) {
     throw Error("Nested kv.mockRouting calls are not supported");
   }
 
-  const _logWithLevel = Logger.prototype._logWithLevel;
   const ruleCounts = {};
 
   Logger.prototype._logWithLevel = (logLvl, metadata, userdata) => {
@@ -202,7 +203,9 @@ module.exports.mockRouting = (cb) => {
     this.formatter = formatter;
     this.logWriter = logWriter;
   };
-  (Logger.prototype._logWithLevel as any).isMocked = true;
+
+  const stfuTypeScript: any = Logger.prototype._logWithLevel;
+  stfuTypeScript.isMocked = true;
 
   const done = () => {
     Logger.prototype._logWithLevel = _logWithLevel;

--- a/lib/logger/logger.ts
+++ b/lib/logger/logger.ts
@@ -21,6 +21,13 @@ var LOG_LEVEL_ENUM = {
 
 const assign = Object.assign || _.assign; // Use the faster Object.assign if possible
 
+let globalRouter;
+
+function setGlobalRouting(filename) {
+  globalRouter = new router.Router();
+  globalRouter.loadConfig(filename);
+}
+
 // This is a port from kayvee-go/logger/logger.go
 class Logger {
   formatter = null;
@@ -37,9 +44,8 @@ class Logger {
     this.logWriter = output;
   }
 
-  setRoutingConfig(filename, cb) {
-    this.logRouter = new router.Router();
-    this.logRouter.loadConfig(filename, cb);
+  setRouter(r) {
+    this.logRouter = r;
   }
 
   setConfig(source, logLvl, formatter, output) {
@@ -161,12 +167,15 @@ class Logger {
     const data = assign({level: logLvl}, this.globals, metadata, userdata);
     if (this.logRouter != null) {
       data._kvmeta = this.logRouter.route(data);
+    } else if (globalRouter) {
+      data._kvmeta = globalRouter.route(data);
     }
     this.logWriter(this.formatter(data));
   }
 }
 
 module.exports = Logger;
+module.exports.setGlobalRouting = setGlobalRouting;
 _.extend(module.exports, LEVELS);
 module.exports.LEVELS = ["debug", "info", "warn", "error", "critical"];
 module.exports.METRICS = ["counter", "gauge"];

--- a/lib/logger/logger.ts
+++ b/lib/logger/logger.ts
@@ -177,6 +177,10 @@ class Logger {
 module.exports = Logger;
 module.exports.setGlobalRouting = setGlobalRouting;
 module.exports.mockRouting = (cb) => {
+  if((Logger.prototype._logWithLevel as any).isMocked) {
+    throw Error("Nested kv.mockRouting calls are not supported");
+  }
+
   const _logWithLevel = Logger.prototype._logWithLevel;
   const ruleCounts = {};
 
@@ -198,6 +202,7 @@ module.exports.mockRouting = (cb) => {
     this.formatter = formatter;
     this.logWriter = logWriter;
   };
+  (Logger.prototype._logWithLevel as any).isMocked = true;
 
   const done = () => {
     Logger.prototype._logWithLevel = _logWithLevel;

--- a/lib/logger/logger.ts
+++ b/lib/logger/logger.ts
@@ -165,7 +165,7 @@ class Logger {
       return;
     }
     const data = assign({level: logLvl}, this.globals, metadata, userdata);
-    if (this.logRouter != null) {
+    if (this.logRouter) {
       data._kvmeta = this.logRouter.route(data);
     } else if (globalRouter) {
       data._kvmeta = globalRouter.route(data);


### PR DESCRIPTION
- Added `setGlobalRouting` method to parallel kayvee-go
- Added `mockRouting` (See README for usage example)

Context: https://clever.atlassian.net/browse/INFRA-1962