### PR TITLE
Added support for wildcard and bool matching

### DIFF
--- a/lib/router/index.ts
+++ b/lib/router/index.ts
@@ -49,7 +49,7 @@ function deepKey(obj, key) {
 function fieldMatches(obj, field, values) {
   const val = obj[field] || deepKey(obj, field);
 
-  if (val == null) {
+  if (val == null || val === "") {
     return false;
   }
 

--- a/lib/router/index.ts
+++ b/lib/router/index.ts
@@ -49,8 +49,12 @@ function deepKey(obj, key) {
 function fieldMatches(obj, field, values) {
   const val = obj[field] || deepKey(obj, field);
 
-  if (!val) {
+  if (val == null) {
     return false;
+  }
+
+  if (values[0] === "*") {
+    return true;
   }
 
   for (let i = 0; i < values.length; i++) {
@@ -81,6 +85,17 @@ class Rule {
     if (envMissing.length > 0) {
       throw new Error(`Missing env var(s): ${envMissing.join(", ")}`);
     }
+
+    Object.keys(matchers).forEach((field) => {
+      const fieldVals = matchers[field];
+      if (fieldVals.indexOf("*") !== -1 && fieldVals.length > 1) {
+        throw new Error(
+          `Invalid matcher values in ${name}.${field}.\n` +
+          "Wildcard matcher can't co-exist with other matchers."
+        );
+      }
+    });
+
     this.output.rule = this.name;
   }
 

--- a/test/router.ts
+++ b/test/router.ts
@@ -163,8 +163,8 @@ routes:
       let config;
 
       config = `
-route: # Shouldn't routes (plural)
-  non-string-values:
+route: # Should be routes (plural)
+  string-values:
     matchers:
       errors: [ "type-o" ]
     output:
@@ -175,8 +175,8 @@ route: # Shouldn't routes (plural)
 
       config = `
 routes:
-  non-string-values:
-    matcher: # Shouldn't matches (plural)
+  string-values:
+    matcher: # Should be matchers (plural)
       errors: [ "type-o" ]
     output:
       type: "analytics"
@@ -186,18 +186,7 @@ routes:
 
       config = `
 routes:
-  $non-string-values: # Invalid rule name
-    matchers:
-      errors: [ "type-o" ]
-    output:
-      type: "analytics"
-      series: "fun"
-`;
-      assert.throws(() => actual._loadConfigString(config));
-
-      config = `
-routes:
-  $non-string-values: # Invalid rule name
+  string-values:
     matchers:
       errors: [ "type-o" ]
     outputs: # Should be output (signular)
@@ -205,15 +194,10 @@ routes:
       series: "fun"
 `;
       assert.throws(() => actual._loadConfigString(config));
-    });
-
-    it("errors on type-os", () => {
-      const actual = new router.Router();
-      let config;
 
       config = `
-route: # Shouldn't routes (plural)
-  non-string-values:
+routes:
+  $invalid-string-values: # Invalid rule name
     matchers:
       errors: [ "type-o" ]
     output:
@@ -224,33 +208,11 @@ route: # Shouldn't routes (plural)
 
       config = `
 routes:
-  non-string-values:
-    matcher: # Shouldn't matches (plural)
-      errors: [ "type-o" ]
-    output:
-      type: "analytics"
-      series: "fun"
-`;
-      assert.throws(() => actual._loadConfigString(config));
-
-      config = `
-routes:
-  $non-string-values: # Invalid rule name
+  string-values:
     matchers:
       errors: [ "type-o" ]
     output:
-      type: "analytics"
-      series: "fun"
-`;
-      assert.throws(() => actual._loadConfigString(config));
-
-      config = `
-routes:
-  $non-string-values: # Invalid rule name
-    matchers:
-      errors: [ "type-o" ]
-    outputs: # Should be output (signular)
-      type: "analytics"
+      type: "analytic" # Should be analytics (plural)p
       series: "fun"
 `;
       assert.throws(() => actual._loadConfigString(config));

--- a/test/router.ts
+++ b/test/router.ts
@@ -216,6 +216,17 @@ routes:
       series: "fun"
 `;
       assert.throws(() => actual._loadConfigString(config));
+
+      config = `
+routes:
+  string-values:
+    matchers:
+      errors: [ "*", "type-o" ] # A wildcard cannot exist with other matchers
+    output:
+      type: "analytics"
+      series: "fun"
+`;
+      assert.throws(() => actual._loadConfigString(config));
     });
   });
 
@@ -343,6 +354,38 @@ describe("router.Rule", () => {
       assert(!r.matches({
         title: "greeting",
         foo: "hi",
+      }));
+    });
+    it("wild card matching", () => {
+      const r = new router.Rule("test-rule", {any: ["*"]}, {});
+      assert(r.matches({
+        any: "",
+      }));
+      assert(r.matches({
+        any: false,
+      }));
+      assert(r.matches({
+        any: 5,
+      }));
+      assert(r.matches({
+        any: "hello",
+      }));
+      assert(r.matches({
+        any: {
+          bar: "hi",
+        },
+      }));
+      assert(!r.matches({
+        any: null,
+      }));
+      assert(!r.matches({
+        any: undefined,
+      }));
+      assert(!r.matches({
+        title: "greeting",
+        foo: {
+          bar: "howdy",
+        },
       }));
     });
   });

--- a/test/router.ts
+++ b/test/router.ts
@@ -388,6 +388,28 @@ describe("router.Rule", () => {
         },
       }));
     });
+    it("bool matching", () => {
+      const r = new router.Rule("test-rule", {bull: [true]}, {});
+      assert(r.matches({
+        bull: true,
+      }));
+      assert(r.matches({
+        any: false,
+        bull: true,
+      }));
+      assert(!r.matches({
+        bull: false,
+      }));
+      assert(!r.matches({
+        bull: "false",
+      }));
+      assert(!r.matches({
+        title: "greeting",
+        foo: {
+          bar: "howdy",
+        },
+      }));
+    });
   });
 
   describe("outputFor", () => {

--- a/test/router.ts
+++ b/test/router.ts
@@ -359,9 +359,6 @@ describe("router.Rule", () => {
     it("wild card matching", () => {
       const r = new router.Rule("test-rule", {any: ["*"]}, {});
       assert(r.matches({
-        any: "",
-      }));
-      assert(r.matches({
         any: false,
       }));
       assert(r.matches({
@@ -374,6 +371,9 @@ describe("router.Rule", () => {
         any: {
           bar: "hi",
         },
+      }));
+      assert(!r.matches({
+        any: "",
       }));
       assert(!r.matches({
         any: null,


### PR DESCRIPTION
A number of existing rules have `!= NIL` matches.  We don't want to add support for a `not` operator in log-routing (unclear about syntax and has significant performance and safety ramifications), so it seemed most natural to add `*` which means it'll match anything.  If `*` is used in a matcher, no other values can be specified.

Added support for bools because a number of rules look for booleans and because a number of well-entrenched bool flags already exist (ex: canary, signaled, is_paid, is_demo).