### PR TITLE
logger: update mockRouter to return route data

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ kv.mockRouting(kvdone => { // Don't nest kv.mockRouting calls!!
     main(err => {
         assert.ifError(err);
 
-        let ruleCounts = kvdone();
-        assert.equal(ruleCounts["key-val"], 1);
+        let ruleMatches = kvdone();
+        assert.equal(ruleMatches["key-val"].length, 1);
     });
 });
 ```

--- a/lib/logger/logger.ts
+++ b/lib/logger/logger.ts
@@ -199,7 +199,7 @@ module.exports.mockRouting = (cb) => {
       if (!msg._kvmeta) { return; }
 
       msg._kvmeta.routes.forEach(route => {
-        ruleMatches[route.rule] = (ruleMatches[route.rule] || []).concat(msg);
+        ruleMatches[route.rule] = (ruleMatches[route.rule] || []).concat(route);
       });
     };
 

--- a/lib/logger/logger.ts
+++ b/lib/logger/logger.ts
@@ -188,7 +188,7 @@ module.exports.mockRouting = (cb) => {
     throw Error("Nested kv.mockRouting calls are not supported");
   }
 
-  const ruleCounts = {};
+  const ruleMatches = {};
 
   Logger.prototype._logWithLevel = (logLvl, metadata, userdata) => {
     const formatter = this.formatter;
@@ -199,7 +199,7 @@ module.exports.mockRouting = (cb) => {
       if (!msg._kvmeta) { return; }
 
       msg._kvmeta.routes.forEach(route => {
-        ruleCounts[route.rule] = 1 + (ruleCounts[route.rule] || 0);
+        ruleMatches[route.rule] = (ruleMatches[route.rule] || []).concat(msg);
       });
     };
 
@@ -214,7 +214,7 @@ module.exports.mockRouting = (cb) => {
 
   const done = () => {
     Logger.prototype._logWithLevel = _logWithLevel;
-    return ruleCounts;
+    return ruleMatches;
   };
 
   cb(done);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kayvee",
   "description": "Write data to key=val pairs, for human and machine readability",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/test/kvconfig.yml
+++ b/test/kvconfig.yml
@@ -5,3 +5,9 @@ routes:
     output:
       type: "analytics"
       series: "requests.everything"
+  rule-two:
+    matchers:
+      title: [ "foo-title" ]
+    output:
+      type: "analytics"
+      series: "requests.everything"

--- a/test/logger_test.ts
+++ b/test/logger_test.ts
@@ -360,23 +360,12 @@ describe("mockRouting", () => {
       assert.equal(ruleMatches["rule-two"].length, 1);
 
       // matched log should look like so
-      const expectedLog = {
-        title: "foo-title",
-        level: "info",
-        _kvmeta: {
-          team: "UNSET",
-          kv_version: "3.3.0",
-          kv_language: "js",
-          routes: [
-            {
-              type: "analytics",
-              series: "requests.everything",
-              rule: "rule-two",
-            },
-          ],
-        },
+      const expectedRule = {
+        type: "analytics",
+        series: "requests.everything",
+        rule: "rule-two",
       };
-      assert.deepEqual(ruleMatches["rule-two"][0], expectedLog);
+      assert.deepEqual(ruleMatches["rule-two"][0], expectedRule);
     });
   });
 });

--- a/test/logger_test.ts
+++ b/test/logger_test.ts
@@ -347,3 +347,36 @@ describe("logger_test", () => {
     });
   });
 });
+
+describe("mockRouting", () => {
+  it("can override routing from setGlobalRouting, and captures routed logs", () => {
+    KayveeLogger.mockRouting(kvdone => {
+      KayveeLogger.setGlobalRouting("test/kvconfig.yml");
+      const logObj = new KayveeLogger("test-source");
+      logObj.info("foo-title");
+      const ruleMatches = kvdone();
+
+      // should match one log
+      assert.equal(ruleMatches["rule-two"].length, 1);
+
+      // matched log should look like so
+      const expectedLog = {
+        title: "foo-title",
+        level: "info",
+        _kvmeta: {
+          team: "UNSET",
+          kv_version: "3.3.0",
+          kv_language: "js",
+          routes: [
+            {
+              type: "analytics",
+              series: "requests.everything",
+              rule: "rule-two",
+            },
+          ],
+        },
+      };
+      assert.deepEqual(ruleMatches["rule-two"][0], expectedLog);
+    });
+  });
+});


### PR DESCRIPTION
previously, just counted the number of logs that matched each rule.
also, adds test coverage.