### PR TITLE
Made value_field an optional setting on metrics and alerts outputs

### DIFF
--- a/lib/router/index.ts
+++ b/lib/router/index.ts
@@ -96,6 +96,10 @@ class Rule {
       }
     });
 
+    if (this.output.type === "alerts" || this.output.type === "metrics") {
+      this.output.value_field = this.output.value_field || "value";
+    }
+
     this.output.rule = this.name;
   }
 

--- a/lib/router/schema_definitions.json
+++ b/lib/router/schema_definitions.json
@@ -1,5 +1,5 @@
 {
-  "description": "Last modified: 01/04/2017",
+  "description": "Last modified: 01/18/2017",
   "required": ["routes"],
   "properties": {
     "routes": { "$ref": "#/definitions/routes" }
@@ -42,35 +42,53 @@
     "metricsOutput": {
       "title": "Metrics Output",
       "type": "object",
-      "additionalProperties": false,
-      "required": ["type", "series", "dimensions"],
-      "properties": {
-        "type": {
-          "type": "string",
-          "pattern": "^metrics$"
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "required": ["type", "series", "dimensions"],
+          "properties": {
+            "type": { "type": "string", "pattern": "^metrics$" },
+            "series": { "$ref": "#/definitions/envVarSubstValue" },
+            "dimensions": { "$ref": "#/definitions/flatValueArr" }
+          }
         },
-        "series": { "$ref": "#/definitions/envVarSubstValue" },
-        "dimensions": { "$ref": "#/definitions/flatValueArr" },
-        "value": { "$ref": "#/definitions/flatValue" }
-      }
+        {
+          "additionalProperties": false,
+          "required": ["type", "series", "dimensions", "value_field"],
+          "properties": {
+            "type": { "type": "string", "pattern": "^metrics$" },
+            "series": { "$ref": "#/definitions/envVarSubstValue" },
+            "dimensions": { "$ref": "#/definitions/flatValueArr" },
+            "value_field": { "$ref": "#/definitions/flatValue" }
+          }
+        }
+      ]
     },
     "alertsOutput": {
       "type": "object",
-      "additionalProperties": false,
-      "required": ["type", "series", "dimensions", "stat_type"],
-      "properties": {
-        "type": {
-          "type": "string",
-          "pattern": "^alerts$"
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "required": ["type", "series", "dimensions", "stat_type"],
+          "properties": {
+            "type": { "type": "string", "pattern": "^alerts$" },
+            "series": { "$ref": "#/definitions/envVarSubstValue" },
+            "dimensions": { "$ref": "#/definitions/flatValueArr" },
+            "stat_type": { "type": "string", "enum": ["counter", "gauge"] }
+          }
         },
-        "series": { "$ref": "#/definitions/envVarSubstValue" },
-        "dimensions": { "$ref": "#/definitions/flatValueArr" },
-        "value": { "$ref": "#/definitions/flatValue" },
-        "stat_type": {
-          "type": "string",
-          "enum": ["counter", "gauge"]
+        {
+          "additionalProperties": false,
+          "required": ["type", "series", "dimensions", "stat_type", "value_field"],
+          "properties": {
+            "type": { "type": "string", "pattern": "^alerts$" },
+            "series": { "$ref": "#/definitions/envVarSubstValue" },
+            "dimensions": { "$ref": "#/definitions/flatValueArr" },
+            "stat_type": { "type": "string", "enum": ["counter", "gauge"] },
+            "value_field": { "$ref": "#/definitions/flatValue" }
+          }
         }
-      }
+      ]
     },
     "analyticsOutput": {
       "type": "object",

--- a/test/router.ts
+++ b/test/router.ts
@@ -25,6 +25,16 @@ routes:
       series: "other-series"
       dimensions: ["baz"]
       stat_type: "gauge"
+  rule-three:
+    matchers:
+      foo.bar: ["multiple", "matches"]
+      baz: ["whatever"]
+    output:
+      type: "alerts"
+      series: "other-series"
+      dimensions: ["baz"]
+      stat_type: "gauge"
+      value_field: "hello"
 `;
       const expected = [
         new router.Rule("rule-one", {title: ["authorize-app"]}, {
@@ -39,6 +49,14 @@ routes:
           series: "other-series",
           dimensions: ["baz"],
           stat_type: "gauge",
+          value_field: "value",
+        }),
+        new router.Rule("rule-three", {"foo.bar": ["multiple", "matches"], baz: ["whatever"]}, {
+          type: "alerts",
+          series: "other-series",
+          dimensions: ["baz"],
+          stat_type: "gauge",
+          value_field: "hello",
         }),
       ];
       const actual = new router.Router();
@@ -100,7 +118,7 @@ routes:
       type: "alerts"
       series: ${series}
       dimensions: ${dimensions}
-      value: "hihi"
+      value_field: "hihi"
       stat_type: "gauge"
 `;
 
@@ -145,7 +163,6 @@ routes:
     output:
       type: "metrics"${v}
       dimensions: ["dim1", "dim2"]
-      value: "hihi"
 `;
 
       const actual = new router.Router();


### PR DESCRIPTION
Previously alert outputs didn't specify a `value_field` attribute.  This was an issue because the kvmeta filter in log-router expected it to be there.  Adding it should fix log-routing alerts.

Additionally, this PR makes `value_field` an optional field for both metrics and alerts outputs.  When not specified `value_field` defaults to `value`, which means by default the quality specified in `value` property of the matched log line will be sent to signalfx as the time-series's datapoint.

Related:
https://github.com/Clever/log-router/pull/80
https://clever.atlassian.net/browse/INFRA-2133

cc @nathanleiby, @ahsojar 