### PR TITLE
Allow empty dimensions fields on alerts

### DIFF
--- a/lib/router/schema_definitions.json
+++ b/lib/router/schema_definitions.json
@@ -1,5 +1,5 @@
 {
-  "description": "Last modified: 01/18/2017",
+  "description": "Last modified: 02/06/2017",
   "required": ["routes"],
   "properties": {
     "routes": { "$ref": "#/definitions/routes" }
@@ -73,7 +73,11 @@
           "properties": {
             "type": { "type": "string", "pattern": "^alerts$" },
             "series": { "$ref": "#/definitions/envVarSubstValue" },
-            "dimensions": { "$ref": "#/definitions/flatValueArr" },
+            "dimensions": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": { "$ref": "#/definitions/flatValue" }
+            },
             "stat_type": { "type": "string", "enum": ["counter", "gauge"] }
           }
         },
@@ -83,7 +87,11 @@
           "properties": {
             "type": { "type": "string", "pattern": "^alerts$" },
             "series": { "$ref": "#/definitions/envVarSubstValue" },
-            "dimensions": { "$ref": "#/definitions/flatValueArr" },
+            "dimensions": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": { "$ref": "#/definitions/flatValue" }
+            },
             "stat_type": { "type": "string", "enum": ["counter", "gauge"] },
             "value_field": { "$ref": "#/definitions/flatValue" }
           }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kayvee",
   "description": "Write data to key=val pairs, for human and machine readability",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/test/router.ts
+++ b/test/router.ts
@@ -35,6 +35,15 @@ routes:
       dimensions: ["baz"]
       stat_type: "gauge"
       value_field: "hello"
+  rule-four:
+    matchers:
+      foo.bar: ["multiple", "matches"]
+      baz: ["whatever"]
+    output:
+      type: "alerts"
+      series: "other-series"
+      dimensions: []
+      stat_type: "gauge"
 `;
       const expected = [
         new router.Rule("rule-one", {title: ["authorize-app"]}, {
@@ -57,6 +66,13 @@ routes:
           dimensions: ["baz"],
           stat_type: "gauge",
           value_field: "hello",
+        }),
+        new router.Rule("rule-four", {"foo.bar": ["multiple", "matches"], baz: ["whatever"]}, {
+          type: "alerts",
+          series: "other-series",
+          dimensions: [],
+          stat_type: "gauge",
+          value_field: "value",
         }),
       ];
       const actual = new router.Router();


### PR DESCRIPTION
Currently, it's an error to write an alert without dimensions.

Related:
- https://github.com/Clever/turk-herder/pull/47
- https://github.com/Clever/kayvee-go/pull/50