### PR TITLE
router: allow kvsubst for channel name in notifications

### DIFF
--- a/lib/router/schema_definitions.json
+++ b/lib/router/schema_definitions.json
@@ -119,7 +119,7 @@
           "type": "string",
           "pattern": "^notifications$"
         },
-        "channel": { "$ref": "#/definitions/envVarSubstValue" },
+        "channel": { "$ref": "#/definitions/kvSubstValue" },
         "icon": { "$ref": "#/definitions/envVarSubstValue" },
         "message": { "$ref": "#/definitions/kvSubstValue" },
         "user": { "$ref": "#/definitions/envVarSubstValue" }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kayvee",
   "description": "Write data to key=val pairs, for human and machine readability",
-  "version": "3.7.2",
+  "version": "3.8.0",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/test/router.ts
+++ b/test/router.ts
@@ -12,7 +12,7 @@ routes:
       title: ["authorize-app"]
     output:
       type: "notifications"
-      channel: "#team"
+      channel: "%{foo.bar}"
       icon: ":rocket:"
       message: "authorized %{foo.bar} in \${SCHOOL}"
       user: "@fishman"
@@ -57,7 +57,7 @@ routes:
       const expected = [
         new router.Rule("rule-one", {title: ["authorize-app"]}, {
           type: "notifications",
-          channel: "#team",
+          channel: "%{foo.bar}",
           icon: ":rocket:",
           message: "authorized %{foo.bar} in Hogwarts",
           user: "@fishman",


### PR DESCRIPTION
allow injecting the channel name in notifications from another kv field

disable support for getting channel name from an env var

Issue: https://clever.atlassian.net/browse/INFRA-2202

Related kayvee-go PR: https://github.com/Clever/kayvee-go/pull/53