### PR TITLE
fix mock logger to have access to globals

### DIFF
--- a/lib/logger/logger.ts
+++ b/lib/logger/logger.ts
@@ -194,7 +194,7 @@ module.exports.mockRouting = (cb) => {
 
   const ruleMatches = {};
 
-  Logger.prototype._logWithLevel = (logLvl, metadata, userdata) => {
+  Logger.prototype._logWithLevel = function (logLvl, metadata, userdata) {
     const formatter = this.formatter;
     const logWriter = this.logWriter;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kayvee",
   "description": "Write data to key=val pairs, for human and machine readability",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/test/kvconfig.yml
+++ b/test/kvconfig.yml
@@ -8,6 +8,7 @@ routes:
   rule-two:
     matchers:
       title: [ "foo-title" ]
+      deploy_env: [ "testing" ]
     output:
       type: "analytics"
       series: "requests.everything"

--- a/test/logger_test.ts
+++ b/test/logger_test.ts
@@ -350,9 +350,9 @@ describe("logger_test", () => {
 
 describe("mockRouting", () => {
   it("can override routing from setGlobalRouting, and captures routed logs", () => {
+    const logObj = new KayveeLogger("test-source");
     KayveeLogger.mockRouting(kvdone => {
       KayveeLogger.setGlobalRouting("test/kvconfig.yml");
-      const logObj = new KayveeLogger("test-source");
       logObj.info("foo-title");
       const ruleMatches = kvdone();
 


### PR DESCRIPTION
context: https://basarat.gitbooks.io/typescript/docs/arrow-functions.html#tip-arrow-functions-with-libraries-that-use-this