### PR TITLE
Added new type of log router - "visualizations"

### DIFF
--- a/lib/router/schema_definitions.json
+++ b/lib/router/schema_definitions.json
@@ -1,5 +1,5 @@
 {
-  "description": "Last modified: 02/08/2017",
+  "description": "Last modified: 06/25/2017",
   "required": ["routes"],
   "properties": {
     "routes": { "$ref": "#/definitions/routes" }
@@ -36,7 +36,8 @@
         { "$ref": "#/definitions/metricsOutput" },
         { "$ref": "#/definitions/alertsOutput" },
         { "$ref": "#/definitions/analyticsOutput" },
-        { "$ref": "#/definitions/notificationsOutput" }
+        { "$ref": "#/definitions/notificationsOutput" },
+        { "$ref": "#/definitions/visualizationsOutput" }
       ]
     },
     "metricsOutput": {
@@ -123,6 +124,18 @@
         "icon": { "$ref": "#/definitions/envVarSubstValue" },
         "message": { "$ref": "#/definitions/kvSubstValue" },
         "user": { "$ref": "#/definitions/envVarSubstValue" }
+      }
+    },
+    "visualizationsOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "topic"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "pattern": "^visualizations$"
+        },
+        "topic": { "$ref": "#/definitions/kvSubstValue" }
       }
     },
     "flatValue": {


### PR DESCRIPTION
Logs that route through "visualizations" can specify a topic (RabbitMQ
style, e.g. dot-deliniated string) that the data relates to. Data will
then flow through the log routing pipeline to a non-persistent RabbitMQ
"visualizations" exchange, which clients can bind to for realtime log
visualizations

Putting this out as an idea, still in discussions.