### PR TITLE
Added support for workflow_id/_EXECUTION_NAME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ build: clean
 test: lint test/tests.json $(TESTS)
 
 $(TESTS):
-	_DEPLOY_ENV=testing DEBUG=us:progress NODE_ENV=test node_modules/mocha/bin/mocha --require ts-node/register --timeout 60000 test/$@.ts
+	_DEPLOY_ENV=testing _EXECUTION_NAME=abc DEBUG=us:progress NODE_ENV=test \
+	node_modules/mocha/bin/mocha --require ts-node/register --timeout 60000 test/$@.ts
 
 benchmarks: build benchmark-data
 	node benchmarks/routing.js

--- a/lib/kayvee.ts
+++ b/lib/kayvee.ts
@@ -15,7 +15,11 @@ function replaceErrors(key, value) {
 // Converts a map to a string space-delimited key=val pairs
 function format(data) {
   if (deploy_env || workflow_id) {
-    return JSON.stringify(_.extend({deploy_env, workflow_id}, data), replaceErrors);
+    const extras: any = {};
+    if (deploy_env) { extras.deploy_env = deploy_env; }
+    if (workflow_id) { extras.wf_id = workflow_id; }
+
+    return JSON.stringify(_.extend(extras, data), replaceErrors);
   }
   return JSON.stringify(data, replaceErrors);
 }

--- a/lib/kayvee.ts
+++ b/lib/kayvee.ts
@@ -1,6 +1,7 @@
 var _ = require("underscore");
 
 const deploy_env = process.env._DEPLOY_ENV;
+const workflow_id = process.env._EXECUTION_NAME;
 
 // Encode errors to strings instead of toJSON()
 function replaceErrors(key, value) {
@@ -13,8 +14,8 @@ function replaceErrors(key, value) {
 
 // Converts a map to a string space-delimited key=val pairs
 function format(data) {
-  if (deploy_env) {
-    return JSON.stringify(_.extend({deploy_env}, data), replaceErrors);
+  if (deploy_env || workflow_id) {
+    return JSON.stringify(_.extend({deploy_env, workflow_id}, data), replaceErrors);
   }
   return JSON.stringify(data, replaceErrors);
 }

--- a/lib/logger/logger.ts
+++ b/lib/logger/logger.ts
@@ -51,7 +51,7 @@ class Logger {
       this.globals.deploy_env = process.env._DEPLOY_ENV;
     }
     if (process.env._EXECUTION_NAME) {
-      this.globals.workflow_id = process.env._EXECUTION_NAME;
+      this.globals.wf_id = process.env._EXECUTION_NAME;
     }
   }
 

--- a/lib/logger/logger.ts
+++ b/lib/logger/logger.ts
@@ -50,6 +50,9 @@ class Logger {
     if (process.env._DEPLOY_ENV) {
       this.globals.deploy_env = process.env._DEPLOY_ENV;
     }
+    if (process.env._EXECUTION_NAME) {
+      this.globals.workflow_id = process.env._EXECUTION_NAME;
+    }
   }
 
   setRouter(r) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kayvee",
   "description": "Write data to key=val pairs, for human and machine readability",
-  "version": "3.8.2",
+  "version": "3.9.0",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/test/kayvee.ts
+++ b/test/kayvee.ts
@@ -10,7 +10,7 @@ describe("kayvee", () => {
       it(spec.title, () => {
         const actual = kv.format(spec.input.data);
         const expected = spec.output;
-        assert.deepEqual(JSON.parse(actual), _.extend({deploy_env: "testing", workflow_id: "abc"},
+        assert.deepEqual(JSON.parse(actual), _.extend({deploy_env: "testing", wf_id: "abc"},
                                                       JSON.parse(expected)));
       });
     });
@@ -21,7 +21,7 @@ describe("kayvee", () => {
       const actual = kv.format({err: Error("An Error Message")});
       const expected = {
         deploy_env: "testing",
-        workflow_id: "abc",
+        wf_id: "abc",
         err: "Error: An Error Message",
       };
       assert.deepEqual(JSON.parse(actual), expected);
@@ -33,7 +33,7 @@ describe("kayvee", () => {
       it(spec.title, () => {
         const actual = kv.formatLog(spec.input.source, spec.input.level, spec.input.title, spec.input.data);
         const expected = spec.output;
-        assert.deepEqual(JSON.parse(actual), _.extend({deploy_env: "testing", workflow_id: "abc"},
+        assert.deepEqual(JSON.parse(actual), _.extend({deploy_env: "testing", wf_id: "abc"},
                                                       JSON.parse(expected)));
       });
     });

--- a/test/kayvee.ts
+++ b/test/kayvee.ts
@@ -10,7 +10,7 @@ describe("kayvee", () => {
       it(spec.title, () => {
         const actual = kv.format(spec.input.data);
         const expected = spec.output;
-        assert.deepEqual(JSON.parse(actual), _.extend({deploy_env: "testing"},
+        assert.deepEqual(JSON.parse(actual), _.extend({deploy_env: "testing", workflow_id: "abc"},
                                                       JSON.parse(expected)));
       });
     });
@@ -21,6 +21,7 @@ describe("kayvee", () => {
       const actual = kv.format({err: Error("An Error Message")});
       const expected = {
         deploy_env: "testing",
+        workflow_id: "abc",
         err: "Error: An Error Message",
       };
       assert.deepEqual(JSON.parse(actual), expected);
@@ -32,7 +33,7 @@ describe("kayvee", () => {
       it(spec.title, () => {
         const actual = kv.formatLog(spec.input.source, spec.input.level, spec.input.title, spec.input.data);
         const expected = spec.output;
-        assert.deepEqual(JSON.parse(actual), _.extend({deploy_env: "testing"},
+        assert.deepEqual(JSON.parse(actual), _.extend({deploy_env: "testing", workflow_id: "abc"},
                                                       JSON.parse(expected)));
       });
     });

--- a/test/logger_test.ts
+++ b/test/logger_test.ts
@@ -56,12 +56,12 @@ describe("logger_test", () => {
       // Invalid log levels will default to debug
       logObj.setLogLevel("invalidloglevel");
       logObj.debug("testlogdebug");
-      let expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Debug}", "title": "testlogdebug"}`;
+      let expected = `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Debug}", "title": "testlogdebug"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
 
       logObj.setLogLevel("sometest");
       logObj.info("testloginfo");
-      expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Info}", "title": "testloginfo"}`;
+      expected = `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Info}", "title": "testloginfo"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
   });
@@ -69,12 +69,12 @@ describe("logger_test", () => {
     it("test debug function", () => {
       logObj.debug("testlogdebug");
       const expected =
-        `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Debug}", "title": "testlogdebug"}`;
+        `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Debug}", "title": "testlogdebug"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
     it("test debugD function", () => {
       logObj.debugD("testlogdebug", {key1: "val1", key2: "val2"});
-      const expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester",
+      const expected = `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester",
 "level": "${KayveeLogger.Debug}", "title": "testlogdebug","key1": "val1", "key2": "val2"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
@@ -83,12 +83,12 @@ describe("logger_test", () => {
   describe(".info", () => {
     it("test info function", () => {
       logObj.info("testloginfo");
-      const expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Info}", "title": "testloginfo"}`;
+      const expected = `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Info}", "title": "testloginfo"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
     it("test infoD function", () => {
       logObj.infoD("testloginfo", {key1: "val1", key2: "val2"});
-      const expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester",
+      const expected = `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester",
 "level": "${KayveeLogger.Info}", "title": "testloginfo","key1": "val1", "key2": "val2"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
@@ -98,12 +98,12 @@ describe("logger_test", () => {
     it("test warn function", () => {
       logObj.warn("testlogwarning");
       const expected =
-        `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Warning}", "title": "testlogwarning"}`;
+        `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Warning}", "title": "testlogwarning"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
     it("test warnD function", () => {
       logObj.warnD("testlogwarning", {key1: "val1", key2: "val2"});
-      const expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester",
+      const expected = `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester",
 "level": "${KayveeLogger.Warning}", "title": "testlogwarning","key1": "val1", "key2": "val2"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
@@ -113,12 +113,12 @@ describe("logger_test", () => {
     it("test error function", () => {
       logObj.error("testlogerror");
       const expected =
-        `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Error}", "title": "testlogerror"}`;
+        `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Error}", "title": "testlogerror"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
     it("test errorD function", () => {
       logObj.errorD("testlogerror", {key1: "val1", key2: "val2"});
-      const expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester",
+      const expected = `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester",
 "level": "${KayveeLogger.Error}", "title": "testlogerror","key1": "val1", "key2": "val2"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
@@ -128,12 +128,12 @@ describe("logger_test", () => {
     it("test critical function", () => {
       logObj.critical("testlogcritical");
       const expected =
-        `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Critical}", "title": "testlogcritical"}`;
+        `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Critical}", "title": "testlogcritical"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
     it("test criticalD function", () => {
       logObj.criticalD("testlogcritical", {key1: "val1", key2: "val2"});
-      const expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester",
+      const expected = `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester",
 "level": "${KayveeLogger.Critical}", "title": "testlogcritical","key1": "val1", "key2": "val2"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
@@ -142,13 +142,13 @@ describe("logger_test", () => {
   describe(".counter", () => {
     it("test counter function", () => {
       logObj.counter("testlogcounter");
-      const expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester",
+      const expected = `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester",
 "level": "${KayveeLogger.Info}", "title": "testlogcounter", "type": "counter", "value": 1}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
     it("test counterD function", () => {
       logObj.counterD("testlogcounter", 2, {key1: "val1", key2: "val2"});
-      const expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester",
+      const expected = `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester",
 "level": "${KayveeLogger.Info}", "title": "testlogcounter","type": "counter", "value": 2,"key1": "val1",` +
         " \"key2\": \"val2\"}";
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
@@ -157,7 +157,7 @@ describe("logger_test", () => {
       logObj.counterD("testlogcounter", 2, {key1: "val1", key2: "val2", value: 18});
       const expected = {
         deploy_env: "testing",
-        workflow_id: "abc",
+        wf_id: "abc",
         source: "logger-tester",
         level: KayveeLogger.Info,
         title: "testlogcounter",
@@ -173,13 +173,13 @@ describe("logger_test", () => {
   describe(".gauge", () => {
     it("test gauge function", () => {
       logObj.gauge("testloggauge", 0);
-      const expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester",
+      const expected = `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester",
 "level": "${KayveeLogger.Info}", "title": "testloggauge", "type": "gauge", "value": 0}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
     it("test gaugeD function", () => {
       logObj.gaugeD("testloggauge", 4, {key1: "val1", key2: "val2"});
-      const expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester",
+      const expected = `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester",
 "level": "${KayveeLogger.Info}", "title": "testloggauge", "type": "gauge", "value": 4, "key1": "val1", "key2": "val2"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
@@ -187,7 +187,7 @@ describe("logger_test", () => {
       logObj.gaugeD("testloggauge", 4, {key1: "val1", key2: "val2", value: 18});
       const expected = {
         deploy_env: "testing",
-        workflow_id: "abc",
+        wf_id: "abc",
         source: "logger-tester",
         level: KayveeLogger.Info,
         title: "testloggauge",
@@ -242,7 +242,7 @@ describe("logger_test", () => {
 
       const output = {
         deploy_env: "testing",
-        workflow_id: "abc",
+        wf_id: "abc",
         fun: "boo",
         level: "info",
         obj:  {
@@ -315,7 +315,7 @@ describe("logger_test", () => {
       logObj.warnD("global-override", {source: "overrided"});
       const output = {
         deploy_env: "testing",
-        workflow_id: "abc",
+        wf_id: "abc",
         title: "global-override",
         source: "overrided",
         level: "warning",
@@ -348,11 +348,11 @@ describe("logger_test", () => {
       logObj2.info("testloginfo");
 
       const loggerExpected =
-        `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Warning}", "title": "testlogwarning"}`;
+        `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Warning}", "title": "testlogwarning"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(loggerExpected));
 
       const logger2Expected =
-        `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester2", "level": "${KayveeLogger.Info}", "title": "testloginfo"}`;
+        `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester2", "level": "${KayveeLogger.Info}", "title": "testloginfo"}`;
       assert.deepEqual(JSON.parse(output2), JSON.parse(logger2Expected));
     });
   });

--- a/test/logger_test.ts
+++ b/test/logger_test.ts
@@ -56,24 +56,25 @@ describe("logger_test", () => {
       // Invalid log levels will default to debug
       logObj.setLogLevel("invalidloglevel");
       logObj.debug("testlogdebug");
-      let expected = `{"deploy_env": "testing", "source": "logger-tester", "level": "${KayveeLogger.Debug}", "title": "testlogdebug"}`;
+      let expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Debug}", "title": "testlogdebug"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
 
       logObj.setLogLevel("sometest");
       logObj.info("testloginfo");
-      expected = `{"deploy_env": "testing", "source": "logger-tester", "level": "${KayveeLogger.Info}", "title": "testloginfo"}`;
+      expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Info}", "title": "testloginfo"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
   });
   describe(".debug", () => {
     it("test debug function", () => {
       logObj.debug("testlogdebug");
-      const expected = `{"deploy_env": "testing", "source": "logger-tester", "level": "${KayveeLogger.Debug}", "title": "testlogdebug"}`;
+      const expected =
+        `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Debug}", "title": "testlogdebug"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
     it("test debugD function", () => {
       logObj.debugD("testlogdebug", {key1: "val1", key2: "val2"});
-      const expected = `{"deploy_env": "testing", "source": "logger-tester",
+      const expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester",
 "level": "${KayveeLogger.Debug}", "title": "testlogdebug","key1": "val1", "key2": "val2"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
@@ -82,12 +83,12 @@ describe("logger_test", () => {
   describe(".info", () => {
     it("test info function", () => {
       logObj.info("testloginfo");
-      const expected = `{"deploy_env": "testing", "source": "logger-tester", "level": "${KayveeLogger.Info}", "title": "testloginfo"}`;
+      const expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Info}", "title": "testloginfo"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
     it("test infoD function", () => {
       logObj.infoD("testloginfo", {key1: "val1", key2: "val2"});
-      const expected = `{"deploy_env": "testing", "source": "logger-tester",
+      const expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester",
 "level": "${KayveeLogger.Info}", "title": "testloginfo","key1": "val1", "key2": "val2"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
@@ -96,12 +97,13 @@ describe("logger_test", () => {
   describe(".warning", () => {
     it("test warn function", () => {
       logObj.warn("testlogwarning");
-      const expected = `{"deploy_env": "testing", "source": "logger-tester", "level": "${KayveeLogger.Warning}", "title": "testlogwarning"}`;
+      const expected =
+        `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Warning}", "title": "testlogwarning"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
     it("test warnD function", () => {
       logObj.warnD("testlogwarning", {key1: "val1", key2: "val2"});
-      const expected = `{"deploy_env": "testing", "source": "logger-tester",
+      const expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester",
 "level": "${KayveeLogger.Warning}", "title": "testlogwarning","key1": "val1", "key2": "val2"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
@@ -110,12 +112,13 @@ describe("logger_test", () => {
   describe(".error", () => {
     it("test error function", () => {
       logObj.error("testlogerror");
-      const expected = `{"deploy_env": "testing", "source": "logger-tester", "level": "${KayveeLogger.Error}", "title": "testlogerror"}`;
+      const expected =
+        `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Error}", "title": "testlogerror"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
     it("test errorD function", () => {
       logObj.errorD("testlogerror", {key1: "val1", key2: "val2"});
-      const expected = `{"deploy_env": "testing", "source": "logger-tester",
+      const expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester",
 "level": "${KayveeLogger.Error}", "title": "testlogerror","key1": "val1", "key2": "val2"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
@@ -124,12 +127,13 @@ describe("logger_test", () => {
   describe(".critical", () => {
     it("test critical function", () => {
       logObj.critical("testlogcritical");
-      const expected = `{"deploy_env": "testing", "source": "logger-tester", "level": "${KayveeLogger.Critical}", "title": "testlogcritical"}`;
+      const expected =
+        `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Critical}", "title": "testlogcritical"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
     it("test criticalD function", () => {
       logObj.criticalD("testlogcritical", {key1: "val1", key2: "val2"});
-      const expected = `{"deploy_env": "testing", "source": "logger-tester",
+      const expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester",
 "level": "${KayveeLogger.Critical}", "title": "testlogcritical","key1": "val1", "key2": "val2"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
@@ -138,13 +142,13 @@ describe("logger_test", () => {
   describe(".counter", () => {
     it("test counter function", () => {
       logObj.counter("testlogcounter");
-      const expected = `{"deploy_env": "testing", "source": "logger-tester",
+      const expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester",
 "level": "${KayveeLogger.Info}", "title": "testlogcounter", "type": "counter", "value": 1}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
     it("test counterD function", () => {
       logObj.counterD("testlogcounter", 2, {key1: "val1", key2: "val2"});
-      const expected = `{"deploy_env": "testing", "source": "logger-tester",
+      const expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester",
 "level": "${KayveeLogger.Info}", "title": "testlogcounter","type": "counter", "value": 2,"key1": "val1",` +
         " \"key2\": \"val2\"}";
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
@@ -153,6 +157,7 @@ describe("logger_test", () => {
       logObj.counterD("testlogcounter", 2, {key1: "val1", key2: "val2", value: 18});
       const expected = {
         deploy_env: "testing",
+        workflow_id: "abc",
         source: "logger-tester",
         level: KayveeLogger.Info,
         title: "testlogcounter",
@@ -168,13 +173,13 @@ describe("logger_test", () => {
   describe(".gauge", () => {
     it("test gauge function", () => {
       logObj.gauge("testloggauge", 0);
-      const expected = `{"deploy_env": "testing", "source": "logger-tester",
+      const expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester",
 "level": "${KayveeLogger.Info}", "title": "testloggauge", "type": "gauge", "value": 0}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
     it("test gaugeD function", () => {
       logObj.gaugeD("testloggauge", 4, {key1: "val1", key2: "val2"});
-      const expected = `{"deploy_env": "testing", "source": "logger-tester",
+      const expected = `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester",
 "level": "${KayveeLogger.Info}", "title": "testloggauge", "type": "gauge", "value": 4, "key1": "val1", "key2": "val2"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(expected));
     });
@@ -182,6 +187,7 @@ describe("logger_test", () => {
       logObj.gaugeD("testloggauge", 4, {key1: "val1", key2: "val2", value: 18});
       const expected = {
         deploy_env: "testing",
+        workflow_id: "abc",
         source: "logger-tester",
         level: KayveeLogger.Info,
         title: "testloggauge",
@@ -236,6 +242,7 @@ describe("logger_test", () => {
 
       const output = {
         deploy_env: "testing",
+        workflow_id: "abc",
         fun: "boo",
         level: "info",
         obj:  {
@@ -308,6 +315,7 @@ describe("logger_test", () => {
       logObj.warnD("global-override", {source: "overrided"});
       const output = {
         deploy_env: "testing",
+        workflow_id: "abc",
         title: "global-override",
         source: "overrided",
         level: "warning",
@@ -339,10 +347,12 @@ describe("logger_test", () => {
       logObj.warn("testlogwarning");
       logObj2.info("testloginfo");
 
-      const loggerExpected = `{"deploy_env": "testing", "source": "logger-tester", "level": "${KayveeLogger.Warning}", "title": "testlogwarning"}`;
+      const loggerExpected =
+        `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester", "level": "${KayveeLogger.Warning}", "title": "testlogwarning"}`;
       assert.deepEqual(JSON.parse(sample), JSON.parse(loggerExpected));
 
-      const logger2Expected = `{"deploy_env": "testing", "source": "logger-tester2", "level": "${KayveeLogger.Info}", "title": "testloginfo"}`;
+      const logger2Expected =
+        `{"deploy_env": "testing", "workflow_id": "abc", "source": "logger-tester2", "level": "${KayveeLogger.Info}", "title": "testloginfo"}`;
       assert.deepEqual(JSON.parse(output2), JSON.parse(logger2Expected));
     });
   });

--- a/test/middleware.ts
+++ b/test/middleware.ts
@@ -108,6 +108,7 @@ _.each(["http", "express"], (serverType) => {
           title: "request-finished",
           canary: false,
           deploy_env: "testing",
+          workflow_id: "abc",
           source: "test-app",
           _kvmeta: {
             team: "UNSET",
@@ -159,6 +160,7 @@ _.each(["http", "express"], (serverType) => {
           title: "request-finished",
           canary: true,
           deploy_env: "testing",
+          workflow_id: "abc",
           source: "test-app",
           _kvmeta: {
             team: "UNSET",
@@ -214,6 +216,7 @@ _.each(["http", "express"], (serverType) => {
           title: "request-finished",
           canary: false,
           deploy_env: "testing",
+          workflow_id: "abc",
           source: "test-app",
           _kvmeta: {
             team: "UNSET",
@@ -271,6 +274,7 @@ _.each(["http", "express"], (serverType) => {
           title: "request-finished",
           canary: false,
           deploy_env: "testing",
+          workflow_id: "abc",
           source: "test-app",
           _kvmeta: {
             team: "UNSET",
@@ -327,6 +331,7 @@ _.each(["http", "express"], (serverType) => {
           title: "request-finished",
           canary: false,
           deploy_env: "testing",
+          workflow_id: "abc",
           source: "test-app",
           _kvmeta: {
             team: "UNSET",
@@ -384,6 +389,7 @@ _.each(["http", "express"], (serverType) => {
           title: "request-finished",
           canary: false,
           deploy_env: "testing",
+          workflow_id: "abc",
           source: "test-app",
           _kvmeta: {
             team: "UNSET",
@@ -432,6 +438,7 @@ _.each(["http", "express"], (serverType) => {
           global: 1,
           base: 1,
           deploy_env: "testing",
+          workflow_id: "abc",
           source: "test-app",
           _kvmeta: {
             team: "UNSET",
@@ -479,6 +486,7 @@ _.each(["http", "express"], (serverType) => {
           base: 1,
           source: "test-app",
           deploy_env: "testing",
+          workflow_id: "abc",
           _kvmeta: {
             team: "UNSET",
             kv_version: "X.X.X",
@@ -540,6 +548,7 @@ _.each(["http", "express"], (serverType) => {
           title: "request-finished",
           canary: false,
           deploy_env: "testing",
+          workflow_id: "abc",
           source: "test-app",
           _kvmeta: {
             team: "UNSET",

--- a/test/middleware.ts
+++ b/test/middleware.ts
@@ -108,7 +108,7 @@ _.each(["http", "express"], (serverType) => {
           title: "request-finished",
           canary: false,
           deploy_env: "testing",
-          workflow_id: "abc",
+          wf_id: "abc",
           source: "test-app",
           _kvmeta: {
             team: "UNSET",
@@ -160,7 +160,7 @@ _.each(["http", "express"], (serverType) => {
           title: "request-finished",
           canary: true,
           deploy_env: "testing",
-          workflow_id: "abc",
+          wf_id: "abc",
           source: "test-app",
           _kvmeta: {
             team: "UNSET",
@@ -216,7 +216,7 @@ _.each(["http", "express"], (serverType) => {
           title: "request-finished",
           canary: false,
           deploy_env: "testing",
-          workflow_id: "abc",
+          wf_id: "abc",
           source: "test-app",
           _kvmeta: {
             team: "UNSET",
@@ -274,7 +274,7 @@ _.each(["http", "express"], (serverType) => {
           title: "request-finished",
           canary: false,
           deploy_env: "testing",
-          workflow_id: "abc",
+          wf_id: "abc",
           source: "test-app",
           _kvmeta: {
             team: "UNSET",
@@ -331,7 +331,7 @@ _.each(["http", "express"], (serverType) => {
           title: "request-finished",
           canary: false,
           deploy_env: "testing",
-          workflow_id: "abc",
+          wf_id: "abc",
           source: "test-app",
           _kvmeta: {
             team: "UNSET",
@@ -389,7 +389,7 @@ _.each(["http", "express"], (serverType) => {
           title: "request-finished",
           canary: false,
           deploy_env: "testing",
-          workflow_id: "abc",
+          wf_id: "abc",
           source: "test-app",
           _kvmeta: {
             team: "UNSET",
@@ -438,7 +438,7 @@ _.each(["http", "express"], (serverType) => {
           global: 1,
           base: 1,
           deploy_env: "testing",
-          workflow_id: "abc",
+          wf_id: "abc",
           source: "test-app",
           _kvmeta: {
             team: "UNSET",
@@ -486,7 +486,7 @@ _.each(["http", "express"], (serverType) => {
           base: 1,
           source: "test-app",
           deploy_env: "testing",
-          workflow_id: "abc",
+          wf_id: "abc",
           _kvmeta: {
             team: "UNSET",
             kv_version: "X.X.X",
@@ -548,7 +548,7 @@ _.each(["http", "express"], (serverType) => {
           title: "request-finished",
           canary: false,
           deploy_env: "testing",
-          workflow_id: "abc",
+          wf_id: "abc",
           source: "test-app",
           _kvmeta: {
             team: "UNSET",


### PR DESCRIPTION
Similar to how _DEPLOY_ENV works, kayvee will add a parameter called `workflow_id` to every log if there's env-var called _EXECUTION_NAME.

Jira: https://clever.atlassian.net/browse/INFRA-2526