### PR TITLE
[INFRA-3218] CircleCI 1.0 -> 2.0 migration cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,6 @@ jobs:
         command: npm install
         name: npm install
     - run: make build
-    - run: npm install
     - run: npm test
     - run: make benchmarks
+    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/npm-publish $NPM_TOKEN .; fi;


### PR DESCRIPTION
JIRA: [INFRA-3218](https://clever.atlassian.net/browse/INFRA-3218)

Improve on the initial CircleCI autotranslation:
- rm extra npm install
- add back npm publish (accidentally removed) 

previous: https://github.com/Clever/kayvee-js/pull/54/files
