### PR TITLE
instrument logs with pod info

### DIFF
--- a/lib/kayvee.ts
+++ b/lib/kayvee.ts
@@ -2,6 +2,9 @@ var _ = require("underscore");
 
 const deploy_env = process.env._DEPLOY_ENV;
 const workflow_id = process.env._EXECUTION_NAME;
+const pod_id = process.env._POD_ID;
+const pod_region = process.env._POD_REGION;
+const pod_account = process.env._POD_ACCOUNT;
 
 // Encode errors to strings instead of toJSON()
 function replaceErrors(key, value) {
@@ -14,10 +17,13 @@ function replaceErrors(key, value) {
 
 // Converts a map to a string space-delimited key=val pairs
 function format(data) {
-  if (deploy_env || workflow_id) {
+  if (deploy_env || workflow_id || pod_id || pod_account || pod_region) {
     const extras: any = {};
     if (deploy_env) { extras.deploy_env = deploy_env; }
     if (workflow_id) { extras.wf_id = workflow_id; }
+    if (pod_id) { extras["pod-id"] = pod_id; }
+    if (pod_region) { extras["pod-region"] = pod_region; }
+    if (pod_account) { extras["pod-account"] = pod_account; }
 
     return JSON.stringify(_.extend(extras, data), replaceErrors);
   }

--- a/lib/logger/logger.ts
+++ b/lib/logger/logger.ts
@@ -55,6 +55,15 @@ class Logger {
     if (process.env._EXECUTION_NAME) {
       this.globals.wf_id = process.env._EXECUTION_NAME;
     }
+    if (process.env._POD_ID) {
+      this.globals["pod-id"] = process.env._POD_ID;
+    }
+    if (process.env._POD_REGION) {
+      this.globals["pod-region"] = process.env._POD_REGION;
+    }
+    if (process.env._POD_ACCOUNT) {
+      this.globals["pod-account"] = process.env._POD_ACCOUNT;
+    }
   }
 
   setRouter(r) {


### PR DESCRIPTION
**Overview:**: https://clever.atlassian.net/browse/INFRA-3363

The multipod deploy backend in catapult adds a few new environment variables that will be useful when searching logs: the pod ID, the AWS region, and the AWS account where the pod is running. This PR changes kayvee to log these values.
