### PR TITLE
Allow custom_handlers to override base_handlers

### DIFF
--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -261,8 +261,8 @@ var formatLine = (options_arg) => {
     var base_handlers = options.base_handlers || defaultHandlers;
     base_handlers = base_handlers.concat([() => ({source: options.source})]);
 
-    // Execute custom-handlers THEN base-handlers
-    const all_handlers = custom_handlers.concat(base_handlers);
+    // Execute base-handlers THEN custom-handlers
+    const all_handlers = base_handlers.concat(custom_handlers);
     _.extend(data, handlerData(all_handlers, req, res));
 
     if (router) {


### PR DESCRIPTION
I think this was a bug as the outcome doesn't line up with what the comments suggest is the desired functionality. Users _should_ be able to override `base_handlers` by providing `custom_handlers` - but with the way this is currently written we are actually doing the opposite. I switched the order of the concat and we now have the correct behavior.

I tested by manually changing the installed version of `kayvee` in `launchpad` and could override the default handlers.

Launchpad Before (cannot override fields in `defaultHandlers`):
```
{ source.title=launchpad.request-finished, canary:false, district_id:"52c5e88553a943970d001718", ip:"::1", method:"POST", params:<nil>, path:"/in/lpsandbox/api/general/events/search", response-size:2, response-time:286.083ms, route:"/lpsandbox/api/general/events/search", session_id:"d28236c90adddaa059c33ea5e02d03946947", status-code:200, user_id:"52c5e9d0e6ed0694212d69ed", user_type:"student", via:"kayvee-middleware" }
```

Launchpad After (can override `method`, `path`, etc):
```
{ source.title=launchpad.request-finished, canary:false, district_id:"52c5e88553a943970d001718", ip:"::1", method:"BLAH", params:<nil>, path:"/lpsandbox/api/student/districtApps", response-time:7.184283s, route:"BLAH", session_id:"d28236c90adddaa059c33ea5e02d03946947", status-code:200, user_id:"52c5e9d0e6ed0694212d69ed", user_type:"student", via:"kayvee-middleware" }
```