### PR TITLE
basic analyticsLogger that doesn't interact with Firehose

### DIFF
--- a/lib/analytics/analyticslogger.ts
+++ b/lib/analytics/analyticslogger.ts
@@ -1,0 +1,42 @@
+import { Logger } from "../logger/logger";
+
+// This is a port from kayvee-go/logger/analytics/logger.go
+export class AnalyticsLogger {
+  logger: Logger = null;
+  streamName: string = null;
+  errLogger: Logger = null;
+
+  constructor(logger: Logger, streamName: string, dbName: string, errLogger: Logger = null) {
+    this.logger = logger;
+    if (streamName === "" && dbName !== "") {
+      this.streamName = `${process.env._DEPLOY_ENV}--${dbName}`;
+    } else if (streamName !== "" && dbName === "") {
+      this.streamName = streamName;
+    } else {
+      throw new Error("Exactly one of streamName and dbName should be specified");
+    }
+    this.errLogger = errLogger;
+  }
+
+  debugD(data) {
+    this.logger.debugD(this.streamName, data);
+  }
+
+  infoD(data) {
+    this.logger.infoD(this.streamName, data);
+  }
+
+  warnD(data) {
+    this.logger.warnD(this.streamName, data);
+  }
+
+  errorD(data) {
+    this.logger.errorD(this.streamName, data);
+  }
+
+  criticalD(data) {
+    this.logger.criticalD(this.streamName, data);
+  }
+}
+
+module.exports = AnalyticsLogger;

--- a/lib/logger/logger.ts
+++ b/lib/logger/logger.ts
@@ -294,3 +294,5 @@ module.exports.mockRouting = (cb) => {
 _.extend(module.exports, LEVELS);
 module.exports.LEVELS = ["trace", "debug", "info", "warn", "error", "critical"];
 module.exports.METRICS = ["counter", "gauge"];
+
+export { Logger };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kayvee",
   "description": "Write data to key=val pairs, for human and machine readability",
-  "version": "3.16.0",
+  "version": "3.17.0",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/test/analyticslogger_test.ts
+++ b/test/analyticslogger_test.ts
@@ -1,0 +1,86 @@
+var KayveeLogger = require("../lib/logger/logger");
+var AnaLogger = require("../lib/analytics/analyticslogger");
+var assert = require("assert");
+
+let sampleOutput = "";
+function sampleOutputFunc(text) {
+  sampleOutput = text;
+  return sampleOutput;
+}
+
+describe("logger_test", () => {
+  let kvLogObj = null;
+  let anLogObj = null;
+  beforeEach(() => {
+    kvLogObj = new KayveeLogger("logger-tester");
+    kvLogObj.setOutput(sampleOutputFunc);
+    anLogObj = new AnaLogger(kvLogObj, "stream-name", "");
+  });
+
+  describe(".constructor", () => {
+    it("passing in parameters to constructor", () => {
+      anLogObj.debugD({});
+      let expected =
+        '{"deploy_env":"testing","wf_id":"abc","level":"debug","source":"logger-tester","title":"stream-name"}';
+      assert.equal(sampleOutput, expected);
+
+      expected =
+        '{"deploy_env":"testing","wf_id":"abc","level":"debug","source":"logger-tester","title":"testing--db-name"}';
+      anLogObj = new AnaLogger(kvLogObj, "", "db-name");
+      anLogObj.debugD({});
+      assert.equal(sampleOutput, expected);
+
+      assert.throws(() => {
+        anLogObj = new AnaLogger(kvLogObj, "stream-name", "db-name");
+      }, new Error("Exactly one of streamName and dbName should be specified"));
+      assert.throws(() => {
+        anLogObj = new AnaLogger(kvLogObj, "", "");
+      }, new Error("Exactly one of streamName and dbName should be specified"));
+    });
+  });
+
+  describe(".debug", () => {
+    it("test debugD function", () => {
+      anLogObj.debugD({ key1: "val1", key2: "val2" });
+      const expected = `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester",
+"level": "${KayveeLogger.Debug}", "title": "stream-name","key1": "val1", "key2": "val2"}`;
+      assert.deepEqual(JSON.parse(sampleOutput), JSON.parse(expected));
+    });
+  });
+
+  describe(".info", () => {
+    it("test infoD function", () => {
+      anLogObj.infoD({ key1: "val1", key2: "val2" });
+      const expected = `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester",
+"level": "${KayveeLogger.Info}", "title": "stream-name","key1": "val1", "key2": "val2"}`;
+      assert.deepEqual(JSON.parse(sampleOutput), JSON.parse(expected));
+    });
+  });
+
+  describe(".warning", () => {
+    it("test warnD function", () => {
+      anLogObj.warnD({ key1: "val1", key2: "val2" });
+      const expected = `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester",
+"level": "${KayveeLogger.Warning}", "title": "stream-name","key1": "val1", "key2": "val2"}`;
+      assert.deepEqual(JSON.parse(sampleOutput), JSON.parse(expected));
+    });
+  });
+
+  describe(".error", () => {
+    it("test errorD function", () => {
+      anLogObj.errorD({ key1: "val1", key2: "val2" });
+      const expected = `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester",
+"level": "${KayveeLogger.Error}", "title": "stream-name","key1": "val1", "key2": "val2"}`;
+      assert.deepEqual(JSON.parse(sampleOutput), JSON.parse(expected));
+    });
+  });
+
+  describe(".critical", () => {
+    it("test criticalD function", () => {
+      anLogObj.criticalD({ key1: "val1", key2: "val2" });
+      const expected = `{"deploy_env": "testing", "wf_id": "abc", "source": "logger-tester",
+"level": "${KayveeLogger.Critical}", "title": "stream-name","key1": "val1", "key2": "val2"}`;
+      assert.deepEqual(JSON.parse(sampleOutput), JSON.parse(expected));
+    });
+  });
+});


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRANG-4245

We discussed in sprint planning that we might prefer to do the sending to Firehose in Fluent Bit rather than directly in application code, so for now it’d be good to just make a new format that is more separated. Later we can swap out what it actually does to make things go down a different path.